### PR TITLE
Added requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+SQLAlchemy
+PyYAML --global-option="--with-libyaml"


### PR DESCRIPTION
Allows easy installation of required modules using `pip install -r requirements.txt`.
The user has to supply libyaml and a compiler for this to work.