### PR TITLE
Fill `invMetaTypes` table

### DIFF
--- a/tableloader/tableFunctions/types.py
+++ b/tableloader/tableFunctions/types.py
@@ -18,6 +18,7 @@ def importyaml(connection,metadata,sourcePath,language='en'):
     trnTranslations = Table('trnTranslations',metadata)
     certMasteries = Table('certMasteries',metadata)
     invTraits = Table('invTraits',metadata)
+    invMetaTypes = Table('invMetaTypes',metadata)
     print "Importing Types"
     print "Opening Yaml"
     with open(os.path.join(sourcePath,'fsd','typeIDs.yaml'),'r') as yamlstream:
@@ -89,4 +90,6 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                         traitid=result.inserted_primary_key
                         for languageid in trait.get('bonusText',{}):
                             connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid.decode('utf-8'),text=trait['bonusText'][languageid].decode('utf-8'))
+            if typeids[typeid].has_key('metaGroupID') or typeids[typeid].has_key('variationParentTypeID'):
+                connection.execute(invMetaTypes.insert(),typeID=typeid,metaGroupID=typeids[typeid].get('metaGroupID'),parentTypeID=typeids[typeid].get('variationParentTypeID'))
     trans.commit()


### PR DESCRIPTION
Generated SDE databases currently contains `invMetaTypes` table, but it is never filled with data. This PR fills the table using `typeIDs.yaml`.

Data inserted using 20191128 SDE: https://gist.github.com/E-351/440096328e9f94c8088034449ce318b2

Sample use case - pull all item variations:
```sql
with
    META_TYPES_MAP as
    (
        select it.typeID, isnull(imt.parentTypeID, it.typeID) parentTypeID from invTypes it
            left join invMetaTypes imt on imt.typeID = it.typeID
    )
select invType.*
from META_TYPES_MAP base
    inner join META_TYPES_MAP variations on variations.parentTypeID = base.parentTypeID
    inner join invTypes invType on invType.typeID = variations.typeID
where base.typeID = 28710
```