### PR TITLE
updates after upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ target/
 
 # Thumbnails
 ._*
+*.bak
 
 # Files that might appear on external disk
 .Spotlight-V100

--- a/Load.py
+++ b/Load.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine,Table
 import warnings
 
 import sys
-import os
+
 
 
 
@@ -22,9 +22,9 @@ if len(sys.argv)==3:
 else:
     language='en'
 
-import configparser
-loader_dirname = os.path.dirname(os.path.realpath(__file__))
-inifile = os.path.join(loader_dirname, 'sdeloader.cfg')
+import configparser, os
+fileLocation = os.path.dirname(os.path.realpath(__file__))
+inifile=os.path.join(fileLocation,'sdeloader.cfg')
 config = configparser.ConfigParser()
 config.read(inifile)
 destination=config.get('Database',database)
@@ -66,9 +66,14 @@ print("created")
 
 import tableloader.tableFunctions
 
+dogmaTypes.importyaml(connection,metadata,sourcePath,language)
+dogmaEffects.importyaml(connection,metadata,sourcePath,language)
+dogmaAttributes.importyaml(connection,metadata,sourcePath,language)
+dogmaAttributeCategories.importyaml(connection,metadata,sourcePath,language)
 blueprints.importyaml(connection,metadata,sourcePath)
 marketGroups.importyaml(connection,metadata,sourcePath,language)
 metaGroups.importyaml(connection,metadata,sourcePath,language)
+controlTowerResources.importyaml(connection,metadata,sourcePath,language)
 categories.importyaml(connection,metadata,sourcePath,language)
 certificates.importyaml(connection,metadata,sourcePath)
 graphics.importyaml(connection,metadata,sourcePath)
@@ -79,5 +84,5 @@ types.importyaml(connection,metadata,sourcePath,language)
 bsdTables.importyaml(connection,metadata,sourcePath)
 universe.importyaml(connection,metadata,sourcePath)
 universe.buildJumps(connection,database)
-volumes.importVolumes(connection,metadata,loader_dirname)
+volumes.importVolumes(connection,metadata,fileLocation)
 universe.fixStationNames(connection,metadata)

--- a/Load.py
+++ b/Load.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine,Table
 import warnings
 
 import sys
-
+import os
 
 
 
@@ -11,7 +11,7 @@ warnings.filterwarnings('ignore', '^Unicode type received non-unicode bind param
 
 
 if len(sys.argv)<2:
-    print "Load.py destination"
+    print("Load.py destination")
     exit()
 
 
@@ -22,10 +22,10 @@ if len(sys.argv)==3:
 else:
     language='en'
 
-import ConfigParser, os
-fileLocation = os.path.dirname(os.path.realpath(__file__))
-inifile=fileLocation+'/sdeloader.cfg'
-config = ConfigParser.ConfigParser()
+import configparser
+loader_dirname = os.path.dirname(os.path.realpath(__file__))
+inifile = os.path.join(loader_dirname, 'sdeloader.cfg')
+config = configparser.ConfigParser()
 config.read(inifile)
 destination=config.get('Database',database)
 sourcePath=config.get('Files','sourcePath')
@@ -39,7 +39,7 @@ from tableloader.tableFunctions import *
 
 
 
-print "connecting to DB"
+print("connecting to DB")
 
 
 engine = create_engine(destination)
@@ -57,12 +57,12 @@ metadata=metadataCreator(schema)
 
 
 
-print "Creating Tables"
+print("Creating Tables")
 
 metadata.drop_all(engine,checkfirst=True)
 metadata.create_all(engine,checkfirst=True)
 
-print "created"
+print("created")
 
 import tableloader.tableFunctions
 
@@ -79,5 +79,5 @@ types.importyaml(connection,metadata,sourcePath,language)
 bsdTables.importyaml(connection,metadata,sourcePath)
 universe.importyaml(connection,metadata,sourcePath)
 universe.buildJumps(connection,database)
-volumes.importVolumes(connection,metadata,sourcePath)
+volumes.importVolumes(connection,metadata,loader_dirname)
 universe.fixStationNames(connection,metadata)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ For PostgreSQL, you will also need to install `psycopg2`.
 
 Alter the settings in ```sdeloader.cfg```, specifically the DSN/URI for the database you'll be using, and the source path for the SDE files. For MariaDB you want to use ```?charset=utf8mb4``` and for postgresq you want to use ```?client_encoding=utf8```.
 
-Make sure to copy the two csv files (```invVolumes1.csv```, ```invVolumes2.csv```) from the repository directory to the sourcePath defined in ```sdeloader.cfg```.
-
 
 
 Then run the loader:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ For PostgreSQL, you will also need to install `psycopg2`.
 
 # Operation
 
-Alter the settings in sdeloader.cfg, specifically the DSN/URI for the database you'll be using, and the source path for the SDE files.
+Alter the settings in ```sdeloader.cfg```, specifically the DSN/URI for the database you'll be using, and the source path for the SDE files. For MariaDB you want to use ```?charset=utf8mb4``` and for postgresq you want to use ```?client_encoding=utf8```.
 
-Make sure to copy the two csv files to the place you've stuck the SDE.
+Make sure to copy the two csv files (```invVolumes1.csv```, ```invVolumes2.csv```) from the repository directory to the sourcePath defined in ```sdeloader.cfg```.
 
 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ For PostgreSQL, you will also need to install `psycopg2`.
 
 # Operation
 
-Alter the settings in ```sdeloader.cfg```, specifically the DSN/URI for the database you'll be using, and the source path for the SDE files. For MariaDB you want to use ```?charset=utf8mb4``` and for postgresq you want to use ```?client_encoding=utf8```.
+Alter the settings in sdeloader.cfg, specifically the DSN/URI for the database you'll be using, and the source path for the SDE files.
+
+For MariaDB you want to use ```?charset=utf8mb4``` and for postgresq you want to use ```?client_encoding=utf8```.
+
+Make sure to copy the two csv files to the place you've stuck the SDE.
 
 
 

--- a/TypesToJson.py
+++ b/TypesToJson.py
@@ -1,22 +1,22 @@
 # -*- coding: utf-8 -*-
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 import yaml
 import json
 import os
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
-import ConfigParser, os
+import configparser, os
 fileLocation = os.path.dirname(os.path.realpath(__file__))
 inifile=fileLocation+'/sdeloader.cfg'
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(inifile)
 sourcePath=config.get('Files','sourcePath')
 destinationPath=config.get('Files','destinationPath')
@@ -25,10 +25,10 @@ destinationPath=config.get('Files','destinationPath')
 
 
 
-print "opening Yaml"
+print("opening Yaml")
 with open(os.path.join(sourcePath,'fsd','typeIDs.yaml'),'r') as yamlstream:
-    print "importing"
+    print("importing")
     typeids=load(yamlstream,Loader=SafeLoader)
-    print "Yaml Processed into memory"
+    print("Yaml Processed into memory")
     with open(os.path.join(destinationPath,'typeid.json'),"w") as output:
         json.dump(typeids,output)

--- a/TypesToJson.py
+++ b/TypesToJson.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
-import importlib
-importlib.reload(sys)
-import yaml
-import json
 import os
+import json
+
+import yaml
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/exportTypesxlsx.py
+++ b/exportTypesxlsx.py
@@ -4,10 +4,10 @@ import sqlalchemy
 
 database='mysql'
 
-import ConfigParser, os
+import configparser, os
 fileLocation = os.path.dirname(os.path.realpath(__file__))
 inifile=fileLocation+'/sdeloader.cfg'
-config = ConfigParser.ConfigParser()
+config = configparser.ConfigParser()
 config.read(inifile)
 source=config.get('Database',database)
 
@@ -32,7 +32,7 @@ ws = wb.create_sheet()
 first=True
 for row in result:
     if first:
-        ws.append(row.keys())
+        ws.append(list(row.keys()))
         first=False
     ws.append(list(row))
 

--- a/getgroups-esi.py
+++ b/getgroups-esi.py
@@ -1,0 +1,165 @@
+import requests
+from sqlalchemy import create_engine,MetaData,Table,Column,INTEGER,FLOAT,VARCHAR,UnicodeText,DECIMAL,Boolean,select,literal_column
+#import requests_cache
+import redis
+import cachecontrol
+import cachecontrol.caches.redis_cache
+from requests_futures.sessions import FuturesSession
+import requests_futures
+from concurrent.futures import as_completed
+
+from tqdm import tqdm
+import sys
+
+
+def getgroups(grouplist):
+    groupfuture=[]
+    print("getgroups")
+    for groupid in grouplist:
+        if isinstance(groupid,str) and groupid.startswith("https"):
+            groupfuture.append(session.get(str(groupid)))
+        else:
+            groupfuture.append(session.get(grouplookupurl.format(groupid)))
+    badlist=[]
+    pbar = tqdm(total=len(grouplist))
+    for groupdata in as_completed(groupfuture):
+        if groupdata.result().status_code==200:
+            itemjson=groupdata.result().json()
+            item=itemjson.get('group_id')
+            if int(item) in sdegrouplist:
+                try:
+                    connection.execute(invGroups.update().where(invGroups.c.groupID == literal_column(str(item))),
+                               groupID=item,
+                               groupName=itemjson['name'],
+                               categoryID=itemjson.get('category_id',None),
+                               published=itemjson.get('published',False),
+                               )
+                except:
+                    pass
+            else:
+                    connection.execute(invGroups.insert(),
+                               groupID=item,
+                               groupName=itemjson['name'],
+                               categoryID=itemjson.get('category_id',None),
+                               published=itemjson.get('published',False),
+                                )
+        else:
+            badlist.append(groupdata.result().url)
+            print(groupdata.result().url)
+        pbar.update(1)
+    return badlist
+
+
+
+
+
+if len(sys.argv)<2:
+    print("Load.py destination")
+    exit()
+
+
+database=sys.argv[1]
+
+if len(sys.argv)==3:
+    language=sys.argv[2]
+else:
+    language='en'
+
+import configparser, os
+fileLocation = os.path.dirname(os.path.realpath(__file__))
+inifile=fileLocation+'/sdeloader.cfg'
+config = configparser.ConfigParser()
+config.read(inifile)
+destination=config.get('Database',database)
+sourcePath=config.get('Files','sourcePath')
+redis_server=config.get('Redis', 'server')
+redis_db=config.get('Redis', 'db')
+
+
+schema=None
+if database=="postgresschema":
+    schema="evesde"
+
+
+
+
+
+engine = create_engine(destination, echo=False)
+metadata = MetaData(schema=schema)
+connection = engine.connect()
+trans = connection.begin()
+
+
+
+invGroups =  Table('invGroups', metadata,
+            Column('groupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+            Column('categoryID', INTEGER(),index=True),
+            Column('groupName', VARCHAR(length=100)),
+            Column('iconID', INTEGER()),
+            Column('useBasePrice', Boolean(name='invgroup_usebaseprice')),
+            Column('anchored', Boolean(name='invgroup_anchored')),
+            Column('anchorable', Boolean(name='invgroup_anchorable')),
+            Column('fittableNonSingleton', Boolean(name='invgroup_fitnonsingle')),
+            Column('published', Boolean(name='invgroup_published')),
+            schema=schema
+)
+
+
+maingrouplist=[]
+
+groupurl="https://esi.evetech.net/latest/universe/groups/?datasource=tranquility&page={}"
+
+
+
+grouplookupurl='https://esi.evetech.net/latest/universe/groups/{}/'
+
+errorcount=0
+#requests_cache.install_cache("group_cache",backend='redis',expire_after=35000)
+
+#base_session=requests_cache.core.CachedSession(cache_name="item_cache",backend='redis',expire_after=35000)
+redis_connection = redis.Redis(host=redis_server, db=redis_db, retry_on_timeout=True, health_check_interval=30)
+base_session = cachecontrol.CacheControl(requests.session(), cachecontrol.caches.redis_cache.RedisCache(redis_connection))
+
+
+lookup=select([invGroups])
+result=connection.execute(lookup).fetchall()
+
+sdegrouplist=[]
+
+for groupdata in result:
+    sdegrouplist.append(groupdata.groupID)
+
+reqs_num_workers=25
+
+session = FuturesSession(max_workers=reqs_num_workers,session=base_session)
+
+page=1
+
+groups=requests.get(groupurl.format(page))
+
+page+=1
+
+groupjson=groups.json()
+
+maingrouplist=maingrouplist+groupjson
+
+maxpage=int(groups.headers['x-pages'])
+
+pbar = tqdm(total=maxpage)
+
+while page<=maxpage:
+    groups=requests.get(groupurl.format(page))
+    page+=1
+    pbar.update(1)
+    groupjson=groups.json()
+    maingrouplist=maingrouplist+groupjson
+
+print("Page variable is {}".format(page))
+
+firstbadlist=getgroups(maingrouplist)
+print("Getting badlist")
+secondbadlist=getgroups(firstbadlist)
+
+
+trans.commit()
+

--- a/getitems-esi.py
+++ b/getitems-esi.py
@@ -1,0 +1,178 @@
+import requests
+from sqlalchemy import create_engine,MetaData,Table,Column,INTEGER,FLOAT,VARCHAR,UnicodeText,DECIMAL,Boolean,select,literal_column
+#import requests_cache
+import redis
+import cachecontrol
+import cachecontrol.caches.redis_cache
+from requests_futures.sessions import FuturesSession
+import requests_futures
+from concurrent.futures import as_completed
+
+from tqdm import tqdm
+import sys
+
+
+def getitems(typelist):
+    typefuture=[]
+    print("getitems")
+    for typeid in typelist:
+        if isinstance(typeid,str) and typeid.startswith("https"):
+            typefuture.append(session.get(str(typeid)))
+        else:
+            typefuture.append(session.get(typelookupurl.format(typeid)))
+    badlist=[]
+    pbar = tqdm(total=len(typelist))
+    for typedata in as_completed(typefuture):
+        if typedata.result().status_code==200:
+            itemjson=typedata.result().json()
+            item=itemjson.get('type_id')
+            if int(item) in sdetypelist:
+                try:
+                    connection.execute(invTypes.update().where(invTypes.c.typeID == literal_column(str(item))),
+                               typeID=item,
+                               typeName=itemjson['name'],
+                               groupID=itemjson.get('group_id',None),
+                               marketGroupID=itemjson.get('market_group_id',None),
+                               capacity=itemjson.get('capacity',None),
+                               published=itemjson.get('published',False),
+                               portionSize=itemjson.get('portion_size',None),
+                               volume=itemjson['volume'])
+                except:
+                    pass
+            else:
+                    connection.execute(invTypes.insert(),
+                                typeID=item,
+                                typeName=itemjson['name'],
+                                marketGroupID=itemjson.get('market_group_id',None),
+                                groupID=itemjson.get('group_id',None),
+                                published=itemjson.get('published',False),
+                                volume=itemjson.get('volume',None),
+                                capacity=itemjson.get('capacity',None),
+                                portionSize=itemjson.get('portion_size',None),
+                                mass=itemjson.get('mass',None)
+                                )
+        else:
+            badlist.append(typedata.result().url)
+            print(typedata.result().url)
+        pbar.update(1)
+    return badlist
+
+
+
+
+
+if len(sys.argv)<2:
+    print("Load.py destination")
+    exit()
+
+
+database=sys.argv[1]
+
+if len(sys.argv)==3:
+    language=sys.argv[2]
+else:
+    language='en'
+
+import configparser, os
+fileLocation = os.path.dirname(os.path.realpath(__file__))
+inifile=fileLocation+'/sdeloader.cfg'
+config = configparser.ConfigParser()
+config.read(inifile)
+destination=config.get('Database',database)
+sourcePath=config.get('Files','sourcePath')
+redis_server=config.get('Redis', 'server')
+redis_db=config.get('Redis', 'db')
+
+schema=None
+if database=="postgresschema":
+    schema="evesde"
+
+
+
+
+
+engine = create_engine(destination, echo=False)
+metadata = MetaData(schema=schema)
+connection = engine.connect()
+trans = connection.begin()
+
+
+
+invTypes =  Table('invTypes', metadata,
+        Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+        Column('groupID', INTEGER(),index=True),
+        Column('typeName', VARCHAR(length=100)),
+        Column('description',UnicodeText()),
+        Column('mass', FLOAT(precision=53)),
+        Column('volume', FLOAT(precision=53)),
+        Column('capacity', FLOAT(precision=53)),
+        Column('portionSize', INTEGER()),
+        Column('raceID', INTEGER()),
+        Column('basePrice', DECIMAL(precision=19, scale=4)),
+        Column('published', Boolean),
+        Column('marketGroupID', INTEGER()),
+        Column('iconID', INTEGER()),
+        Column('soundID', INTEGER()),
+        Column('graphicID', INTEGER()),
+        schema=schema,
+)
+
+
+maintypelist=[]
+
+groupurl="https://esi.evetech.net/latest/universe/types/?datasource=tranquility&page={}"
+
+
+
+typelookupurl='https://esi.evetech.net/latest/universe/types/{}/'
+
+errorcount=0
+#requests_cache.install_cache("item_cache",backend='redis',expire_after=35000)
+
+#base_session=requests_cache.core.CachedSession(cache_name="item_cache",backend='redis',expire_after=35000)
+redis_connection = redis.Redis(host=redis_server, db=redis_db, retry_on_timeout=True, health_check_interval=30)
+base_session = cachecontrol.CacheControl(requests.session(), cachecontrol.caches.redis_cache.RedisCache(redis_connection))
+
+
+lookup=select([invTypes])
+result=connection.execute(lookup).fetchall()
+
+sdetypelist=[]
+
+for typedata in result:
+    sdetypelist.append(typedata.typeID)
+
+reqs_num_workers=25
+
+session = FuturesSession(max_workers=reqs_num_workers,session=base_session)
+
+page=1
+
+groups=requests.get(groupurl.format(page))
+
+page+=1
+
+groupjson=groups.json()
+
+maintypelist=maintypelist+groupjson
+
+maxpage=int(groups.headers['x-pages'])
+
+pbar = tqdm(total=maxpage)
+
+while page<=maxpage:
+    groups=requests.get(groupurl.format(page))
+    page+=1
+    pbar.update(1)
+    groupjson=groups.json()
+    maintypelist=maintypelist+groupjson
+
+print("Page variable is {}".format(page))
+
+firstbadlist=getitems(maintypelist)
+print("Getting badlist")
+secondbadlist=getitems(firstbadlist)
+
+
+trans.commit()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,15 @@
-SQLAlchemy
-PyYAML --global-option="--with-libyaml"
+CacheControl==0.12.6
+certifi==2020.4.5.2
+chardet==3.0.4
+idna==2.9
+msgpack==1.0.0
+pkg-resources==0.0.0
+PyMySQL==0.9.3
+PyYAML==5.3.1 --global-option="--with-libyaml"
+redis==3.5.3
+requests==2.23.0
+requests-cache==0.5.2
+requests-futures==1.0.0
+SQLAlchemy==1.3.17
+tqdm==4.46.1
+urllib3==1.25.9

--- a/sdeloader.cfg
+++ b/sdeloader.cfg
@@ -8,3 +8,8 @@ mssql=mssql+pymssql://evesde:Dnm24syusKIIvo1@localhost/evesde?charset=utf8
 [Files]
 sourcePath=/tmp/sde
 destinationPath=/tmp/sde/output/
+
+[Redis]
+server=localhost
+db=0
+

--- a/sdeloader.cfg
+++ b/sdeloader.cfg
@@ -1,7 +1,6 @@
 [Database]
-mysql=mysql+pymysql://yaml:yamlpass@localhost/sdeyaml?charset=utf8
-postgres=postgresql+psycopg2://yaml:yaml@localhost/sdeyaml
-postgresschema=postgresql+psycopg2://yaml:yaml@localhost/sdeyamlschema
+mysql=mysql+pymysql://yaml:yamlpass@localhost/sdeyaml?charset=utf8mb4
+postgres=postgresql+psycopg2://yaml:yaml@localhost/sdeyaml?client_encoding=utf8
 sqlite=sqlite+pysqlite:///eve.db
 mssql=mssql+pymssql://evesde:Dnm24syusKIIvo1@localhost/evesde?charset=utf8
 

--- a/tableloader/tableFunctions/__init__.py
+++ b/tableloader/tableFunctions/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ["blueprints","categories","certificates","graphics","groups","icons","skins","types","bsdTables","universe","volumes","marketGroups","metaGroups"]
+__all__ = ["blueprints","categories","certificates","graphics","groups","icons","skins","types","bsdTables","universe","volumes","marketGroups","metaGroups","controlTowerResources","dogmaEffects","dogmaAttributeCategories","dogmaAttributes","dogmaTypes"]

--- a/tableloader/tableFunctions/blueprints.py
+++ b/tableloader/tableFunctions/blueprints.py
@@ -2,17 +2,17 @@
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):
 
-    activityIDs={"copying":5,"manufacturing":1,"research_material":4,"research_time":3,"invention":8,"reaction":11};
+    activityIDs={"copying":5,"manufacturing":1,"research_material":4,"research_time":3,"invention":8,"reaction":11}
 
     industryBlueprints=Table('industryBlueprints',metadata)
     industryActivity = Table('industryActivity',metadata)
@@ -24,12 +24,12 @@ def importyaml(connection,metadata,sourcePath):
     
     
 
-    print "importing Blueprints"
-    print "opening Yaml"
+    print("importing Blueprints")
+    print("opening Yaml")
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','blueprints.yaml'),'r') as yamlstream:
         blueprints=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for blueprint in blueprints:
             connection.execute(industryBlueprints.insert(),typeID=blueprint,maxProductionLimit=blueprints[blueprint]["maxProductionLimit"])
             for activity in blueprints[blueprint]['activities']:
@@ -37,28 +37,28 @@ def importyaml(connection,metadata,sourcePath):
                                     typeID=blueprint,
                                     activityID=activityIDs[activity],
                                     time=blueprints[blueprint]['activities'][activity]['time'])
-                if blueprints[blueprint]['activities'][activity].has_key('materials'):
+                if 'materials' in blueprints[blueprint]['activities'][activity]:
                     for material in blueprints[blueprint]['activities'][activity]['materials']:
                         connection.execute(industryActivityMaterials.insert(),
                                             typeID=blueprint,
                                             activityID=activityIDs[activity],
                                             materialTypeID=material['typeID'],
                                             quantity=material['quantity'])
-                if blueprints[blueprint]['activities'][activity].has_key('products'):
+                if 'products' in blueprints[blueprint]['activities'][activity]:
                     for product in blueprints[blueprint]['activities'][activity]['products']:
                         connection.execute(industryActivityProducts.insert(),
                                             typeID=blueprint,
                                             activityID=activityIDs[activity],
                                             productTypeID=product['typeID'],
                                             quantity=product['quantity'])
-                        if product.has_key('probability'):
+                        if 'probability' in product:
                             connection.execute(industryActivityProbabilities.insert(),
                                                 typeID=blueprint,
                                                 activityID=activityIDs[activity],
                                                 productTypeID=product['typeID'],
                                                 probability=product['probability'])
                 try:
-                    if blueprints[blueprint]['activities'][activity].has_key('skills'):
+                    if 'skills' in blueprints[blueprint]['activities'][activity]:
                         for skill in blueprints[blueprint]['activities'][activity]['skills']:
                             connection.execute(industryActivitySkills.insert(),
                                                 typeID=blueprint,
@@ -66,5 +66,5 @@ def importyaml(connection,metadata,sourcePath):
                                                 skillID=skill['typeID'],
                                                 level=skill['level'])
                 except:
-                    print '{} has a bad skill'.format(blueprint)
+                    print('{} has a bad skill'.format(blueprint))
     trans.commit()

--- a/tableloader/tableFunctions/blueprints.py
+++ b/tableloader/tableFunctions/blueprints.py
@@ -2,7 +2,6 @@
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/bsdTables.py
+++ b/tableloader/tableFunctions/bsdTables.py
@@ -21,8 +21,13 @@ def importyaml(connection,metadata,sourcePath):
     files=glob.glob(os.path.join(sourcePath,'bsd','*.yaml'))
     for file in files:
         head, tail = os.path.split(file)
+
         tablename=tail.split('.')[0]
         print(tablename)
+        if tablename in [ 'dgmAttributeCategories', 'dgmAttributeTypes', 'dgmEffects', 'dgmTypeEffects', 'dgmTypeAttributes' ]:
+            print("skipping {}".format(tablename))
+            continue
+
         tablevar = Table(tablename,metadata)
         print("Importing {}".format(file))
         print("Opening Yaml")

--- a/tableloader/tableFunctions/bsdTables.py
+++ b/tableloader/tableFunctions/bsdTables.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 import os
 import glob
 from sqlalchemy import Table
@@ -9,27 +9,27 @@ from sqlalchemy import Table
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 def importyaml(connection,metadata,sourcePath):
 
-    print "Importing BSD Tables"
+    print("Importing BSD Tables")
 
     files=glob.glob(os.path.join(sourcePath,'bsd','*.yaml'))
     for file in files:
         head, tail = os.path.split(file)
         tablename=tail.split('.')[0]
-        print tablename
+        print(tablename)
         tablevar = Table(tablename,metadata)
-        print "Importing {}".format(file)
-        print "Opening Yaml"
+        print("Importing {}".format(file))
+        print("Opening Yaml")
         trans = connection.begin()
         with open(file,'r') as yamlstream:
             rows=load(yamlstream,Loader=SafeLoader)
-            print "Yaml Processed into memory"
+            print("Yaml Processed into memory")
             for row in rows:
                 connection.execute(tablevar.insert().values(row))
         trans.commit()

--- a/tableloader/tableFunctions/categories.py
+++ b/tableloader/tableFunctions/categories.py
@@ -1,42 +1,42 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 def importyaml(connection,metadata,sourcePath,language='en'):
-    print "Importing Categories"
+    print("Importing Categories")
     invCategories = Table('invCategories',metadata)
     trnTranslations = Table('trnTranslations',metadata)
     
-    print "opening Yaml"
+    print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','categoryIDs.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         categoryids=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for categoryid in categoryids:
             connection.execute(invCategories.insert(),
                             categoryID=categoryid,
-                            categoryName=categoryids[categoryid].get('name',{}).get(language,'').decode('utf-8'),
+                            categoryName=categoryids[categoryid].get('name',{}).get(language,''),
                             iconID=categoryids[categoryid].get('iconID'),
                             published=categoryids[categoryid].get('published',0))
             
-            if (categoryids[categoryid].has_key('name')):
+            if ('name' in categoryids[categoryid]):
                 for lang in categoryids[categoryid]['name']:
                     try:
-                        connection.execute(trnTranslations.insert(),tcID=6,keyID=categoryid,languageID=lang,text=categoryids[categoryid]['name'][lang].decode('utf-8'));
+                        connection.execute(trnTranslations.insert(),tcID=6,keyID=categoryid,languageID=lang,text=categoryids[categoryid]['name'][lang])
                     except:                        
-                        print '{} {} has a category problem'.format(categoryid,lang)
+                        print('{} {} has a category problem'.format(categoryid,lang))
     trans.commit()

--- a/tableloader/tableFunctions/categories.py
+++ b/tableloader/tableFunctions/categories.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
@@ -33,7 +30,7 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                             iconID=categoryids[categoryid].get('iconID'),
                             published=categoryids[categoryid].get('published',0))
             
-            if ('name' in categoryids[categoryid]):
+            if 'name' in categoryids[categoryid]:
                 for lang in categoryids[categoryid]['name']:
                     try:
                         connection.execute(trnTranslations.insert(),tcID=6,keyID=categoryid,languageID=lang,text=categoryids[categoryid]['name'][lang])

--- a/tableloader/tableFunctions/certificates.py
+++ b/tableloader/tableFunctions/certificates.py
@@ -2,16 +2,16 @@
 import sys
 import os
 from sqlalchemy import Table
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 def importyaml(connection,metadata,sourcePath):
@@ -19,12 +19,12 @@ def importyaml(connection,metadata,sourcePath):
     certSkills = Table('certSkills',metadata,)
     skillmap={"basic":0,"standard":1,"improved":2,"advanced":3,"elite":4}
 
-    print "Importing Certificates"
-    print "opening Yaml"
+    print("Importing Certificates")
+    print("opening Yaml")
     with open(os.path.join(sourcePath,'fsd','certificates.yaml'),'r') as yamlstream:
         trans = connection.begin()
         certificates=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for certificate in certificates:
             connection.execute(certCerts.insert(),
                             certID=certificate,

--- a/tableloader/tableFunctions/certificates.py
+++ b/tableloader/tableFunctions/certificates.py
@@ -2,13 +2,10 @@
 import sys
 import os
 from sqlalchemy import Table
-import importlib
-importlib.reload(sys)
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/controlTowerResources.py
+++ b/tableloader/tableFunctions/controlTowerResources.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/controlTowerResources.py
+++ b/tableloader/tableFunctions/controlTowerResources.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+import importlib
+importlib.reload(sys)
+from sqlalchemy import Table
+
+from yaml import load
+try:
+	from yaml import CSafeLoader as SafeLoader
+	print("Using CSafeLoader")
+except ImportError:
+	from yaml import SafeLoader
+	print("Using Python SafeLoader")
+
+
+def importyaml(connection,metadata,sourcePath,language='en'):
+    print("Importing controlTowerResources")
+    invControlTowerResources = Table('invControlTowerResources',metadata)
+    
+    print("opening Yaml")
+        
+    trans = connection.begin()
+    with open(os.path.join(sourcePath,'fsd','controlTowerResources.yaml'),'r') as yamlstream:
+        print("importing")
+        controlTowerResources=load(yamlstream,Loader=SafeLoader)
+        print("Yaml Processed into memory")
+        for controlTowerResourcesid in controlTowerResources:
+            for purpose in controlTowerResources[controlTowerResourcesid]['resources']:
+                connection.execute(invControlTowerResources.insert(),
+                                controlTowerTypeID=controlTowerResourcesid,
+                                resourceTypeID=purpose['resourceTypeID'],
+                                purpose=purpose['purpose'],
+                                quantity=purpose.get('quantity',0),
+                                minSecurityLevel=purpose.get('minSecurityLevel',None),
+                                factionID=purpose.get('factionID',None)
+                )
+    trans.commit()

--- a/tableloader/tableFunctions/dogmaAttributeCategories.py
+++ b/tableloader/tableFunctions/dogmaAttributeCategories.py
@@ -1,31 +1,31 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 
 def importyaml(connection,metadata,sourcePath,language='en'):
-    print "Importing dogma attribute categories"
+    print("Importing dogma attribute categories")
     dgmAttributeCategories = Table('dgmAttributeCategories',metadata)
     
-    print "opening Yaml"
+    print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','dogmaAttributeCategories.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         dogmaAttributeCategories=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for dogmaAttributeCategoryID in dogmaAttributeCategories:
           attribute = dogmaAttributeCategories[dogmaAttributeCategoryID]
           connection.execute(dgmAttributeCategories.insert(),

--- a/tableloader/tableFunctions/dogmaAttributeCategories.py
+++ b/tableloader/tableFunctions/dogmaAttributeCategories.py
@@ -27,10 +27,11 @@ def importyaml(connection,metadata,sourcePath,language='en'):
         dogmaAttributeCategories=load(yamlstream,Loader=SafeLoader)
         print("Yaml Processed into memory")
         for dogmaAttributeCategoryID in dogmaAttributeCategories:
-          attribute = dogmaAttributeCategories[dogmaAttributeCategoryID]
-          connection.execute(dgmAttributeCategories.insert(),
-                             categoryID=dogmaAttributeCategoryID,
-                             categoryName=attribute['name'],
-                             categoryDescription=attribute['description']
-                )
+            attribute = dogmaAttributeCategories[dogmaAttributeCategoryID]
+            connection.execute(dgmAttributeCategories.insert(),
+                categoryID=dogmaAttributeCategoryID,
+                categoryName=attribute['name'],
+                categoryDescription=attribute['description']
+            )
     trans.commit()
+

--- a/tableloader/tableFunctions/dogmaAttributeCategories.py
+++ b/tableloader/tableFunctions/dogmaAttributeCategories.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
-	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
+    from yaml import CSafeLoader as SafeLoader
 except ImportError:
-	from yaml import SafeLoader
-	print("Using Python SafeLoader")
+    from yaml import SafeLoader
+    print("Using Python SafeLoader")
 
 
 

--- a/tableloader/tableFunctions/dogmaAttributes.py
+++ b/tableloader/tableFunctions/dogmaAttributes.py
@@ -17,28 +17,28 @@ except ImportError:
 
 def importyaml(connection,metadata,sourcePath,language='en'):
     print("Importing dogma attributes")
-    dgmAttributes = Table('dgmAttributeTypess',metadata)
+    dgmAttributes = Table('dgmAttributeTypes',metadata)
     
     print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','dogmaAttributes.yaml'),'r') as yamlstream:
         print("importing")
-        dogmaAttributeCategories=load(yamlstream,Loader=SafeLoader)
+        dogmaAttributes=load(yamlstream,Loader=SafeLoader)
         print("Yaml Processed into memory")
         for dogmaAttributeID in dogmaAttributes:
           attribute = dogmaAttributes[dogmaAttributeID]
           connection.execute(dgmAttributes.insert(),
                                attributeID=dogmaAttributeID,
-                               categoryID=attribute['categoryID'],
+                               categoryID=attribute.get('categoryID'),
                                defaultValue=attribute.get('defaultValue'),
                                description=attribute.get('description'),
                                iconID=attribute.get('iconID'),
-                               attributeName=attribute.get('displayNameID',[]).get(language),
+                               attributeName=attribute.get('displayNameID',{}).get(language),
                                published=attribute.get('published'),
                                unitID=attribute.get('unitID'),
                                stackable=attribute.get('stackable'),
                                highIsGood=attribute.get('highIsGood'),
-                               displayName=attribute.get('displayNameID',[]).get(language)
+                               displayName=attribute.get('displayNameID',{}).get(language)
                 )
     trans.commit()

--- a/tableloader/tableFunctions/dogmaAttributes.py
+++ b/tableloader/tableFunctions/dogmaAttributes.py
@@ -1,31 +1,31 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 
 def importyaml(connection,metadata,sourcePath,language='en'):
-    print "Importing dogma attributes"
+    print("Importing dogma attributes")
     dgmAttributes = Table('dgmAttributeTypess',metadata)
     
-    print "opening Yaml"
+    print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','dogmaAttributes.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         dogmaAttributeCategories=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for dogmaAttributeID in dogmaAttributes:
           attribute = dogmaAttributes[dogmaAttributeID]
           connection.execute(dgmAttributes.insert(),

--- a/tableloader/tableFunctions/dogmaAttributes.py
+++ b/tableloader/tableFunctions/dogmaAttributes.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+reload(sys)
+sys.setdefaultencoding("utf-8")
+from sqlalchemy import Table
+
+from yaml import load,dump
+try:
+	from yaml import CSafeLoader as SafeLoader
+	print "Using CSafeLoader"
+except ImportError:
+	from yaml import SafeLoader
+	print "Using Python SafeLoader"
+
+
+
+def importyaml(connection,metadata,sourcePath,language='en'):
+    print "Importing dogma attributes"
+    dgmAttributes = Table('dgmAttributeTypess',metadata)
+    
+    print "opening Yaml"
+        
+    trans = connection.begin()
+    with open(os.path.join(sourcePath,'fsd','dogmaAttributes.yaml'),'r') as yamlstream:
+        print "importing"
+        dogmaAttributeCategories=load(yamlstream,Loader=SafeLoader)
+        print "Yaml Processed into memory"
+        for dogmaAttributeID in dogmaAttributes:
+          attribute = dogmaAttributes[dogmaAttributeID]
+          connection.execute(dgmAttributes.insert(),
+                               attributeID=dogmaAttributeID,
+                               categoryID=attribute['categoryID'],
+                               defaultValue=attribute.get('defaultValue'),
+                               description=attribute.get('description'),
+                               iconID=attribute.get('iconID'),
+                               attributeName=attribute.get('displayNameID',[]).get(language),
+                               published=attribute.get('published'),
+                               unitID=attribute.get('unitID'),
+                               stackable=attribute.get('stackable'),
+                               highIsGood=attribute.get('highIsGood'),
+                               displayName=attribute.get('displayNameID',[]).get(language)
+                )
+    trans.commit()

--- a/tableloader/tableFunctions/dogmaAttributes.py
+++ b/tableloader/tableFunctions/dogmaAttributes.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/dogmaEffects.py
+++ b/tableloader/tableFunctions/dogmaEffects.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 distribution={'twosome':1,'bubble':2}
@@ -19,16 +19,16 @@ effectcategory={}
 
 
 def importyaml(connection,metadata,sourcePath,language='en'):
-    print "Importing dogma effects"
+    print("Importing dogma effects")
     dgmEffects = Table('dgmEffects',metadata)
     
-    print "opening Yaml"
+    print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','dogmaEffects.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         dogmaEffects=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for dogmaEffectsid in dogmaEffects:
             for effect in dogmaEffects[dogmaEffectsid]:
                 connection.execute(dgmEffects.insert(),
@@ -57,7 +57,7 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                                 npcUsageChanceAttributeID=effect.get('npcUsageChanceAttributeID'),
                                 npcActivationChanceAttributeID=effect.get('npcActivationChanceAttributeID'),
                                 fittingUsageChanceAttributeID=effect.get('fittingUsageChanceAttributeID'),
-                                modifierInfo=dump(effect.get('modifierInfo')
+                                modifierInfo=dump(effect.get('modifierInfo'))
                                 
                 )
     trans.commit()

--- a/tableloader/tableFunctions/dogmaEffects.py
+++ b/tableloader/tableFunctions/dogmaEffects.py
@@ -30,14 +30,14 @@ def importyaml(connection,metadata,sourcePath,language='en'):
         dogmaEffects=load(yamlstream,Loader=SafeLoader)
         print("Yaml Processed into memory")
         for dogmaEffectsid in dogmaEffects:
-            for effect in dogmaEffects[dogmaEffectsid]:
-                connection.execute(dgmEffects.insert(),
+            effect=dogmaEffects[dogmaEffectsid]
+            connection.execute(dgmEffects.insert(),
                                 effectID=dogmaEffectsid,
-                                effectName=effect['effectName'],
+                                effectName=effect.get('effectName'),
                                 effectCategory=effectcategory.get(effect['effectCategory']),
-                                description=effect['descriptionID'][language],
-                                guid=effect['guid'],
-                                iconID=effect.get['iconID'],
+                                description=effect.get('descriptionID',{}).get(language),
+                                guid=effect.get('guid'),
+                                iconID=effect.get('iconID'),
                                 isOffensive=effect['isOffensive'],
                                 isAssistance=effect['isAssistance'],
                                 durationAttributeID=effect.get('durationAttributeID'),
@@ -47,7 +47,7 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                                 falloffAttributeID=effect.get('falloffAttributeID'),
                                 disallowAutoRepeat=effect.get('disallowAutoRepeat'),
                                 published=effect.get('published'),
-                                displayName=effect.get('displayNameID',[]).get(language),
+                                displayName=effect.get('displayNameID',{}).get(language),
                                 isWarpSafe=effect.get('isWarpSafe'),
                                 rangeChance=effect.get('rangeChance'),
                                 electronicChance=effect.get('electronicChance'),
@@ -59,5 +59,5 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                                 fittingUsageChanceAttributeID=effect.get('fittingUsageChanceAttributeID'),
                                 modifierInfo=dump(effect.get('modifierInfo'))
                                 
-                )
+            )
     trans.commit()

--- a/tableloader/tableFunctions/dogmaEffects.py
+++ b/tableloader/tableFunctions/dogmaEffects.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/dogmaTypes.py
+++ b/tableloader/tableFunctions/dogmaTypes.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load,dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/dogmaTypes.py
+++ b/tableloader/tableFunctions/dogmaTypes.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+import sys
+import os
+import importlib
+importlib.reload(sys)
+from sqlalchemy import Table
+
+from yaml import load,dump
+try:
+	from yaml import CSafeLoader as SafeLoader
+	print("Using CSafeLoader")
+except ImportError:
+	from yaml import SafeLoader
+	print("Using Python SafeLoader")
+
+
+distribution={'twosome':1,'bubble':2}
+effectcategory={}
+
+
+def importyaml(connection,metadata,sourcePath,language='en'):
+    print("Importing dogma effects")
+    dgmEffects = Table('dgmTypeEffects',metadata)
+    dgmAttributes = Table('dgmTypeAttributes',metadata)
+    
+    print("opening Yaml")
+        
+    trans = connection.begin()
+    with open(os.path.join(sourcePath,'fsd','typeDogma.yaml'),'r') as yamlstream:
+        print("importing")
+        dogmaEffects=load(yamlstream,Loader=SafeLoader)
+        print("Yaml Processed into memory")
+        for typeid in dogmaEffects:
+            for effect in dogmaEffects[typeid]['dogmaEffects']:
+                connection.execute(dgmEffects.insert(),
+                                typeID=typeid,
+                                effectID=effect['effectID'],
+                                isDefault=effect.get('isDefault')
+                )
+            for attribute in dogmaEffects[typeid]['dogmaAttributes']:
+                connection.execute(dgmAttributes.insert(),
+                                typeID=typeid,
+                                attributeID=attribute.get('attributeID'),
+                                valueFloat=attribute.get('value')
+                )
+    trans.commit()

--- a/tableloader/tableFunctions/graphics.py
+++ b/tableloader/tableFunctions/graphics.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
-import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
 
 import os
 import sys
-importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):

--- a/tableloader/tableFunctions/graphics.py
+++ b/tableloader/tableFunctions/graphics.py
@@ -1,27 +1,27 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
+import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):
     eveGraphics = Table('eveGraphics',metadata)
-    print "Importing Graphics"
-    print "opening Yaml"
+    print("Importing Graphics")
+    print("opening Yaml")
     with open(os.path.join(sourcePath,'fsd','graphicIDs.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         trans = connection.begin()
         graphics=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for graphic in graphics:
             connection.execute(eveGraphics.insert(),
                             graphicID=graphic,

--- a/tableloader/tableFunctions/groups.py
+++ b/tableloader/tableFunctions/groups.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
-import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
 
 import os
 import sys
-importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath,language='en'):
@@ -33,7 +30,7 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                             anchorable=groupids[groupid].get('anchorable',0),
                             fittableNonSingleton=groupids[groupid].get('fittableNonSingleton',0),
                             published=groupids[groupid].get('published',0))
-            if ('name' in groupids[groupid]):
+            if 'name' in groupids[groupid]:
                 for lang in groupids[groupid]['name']:
                     connection.execute(trnTranslations.insert(),tcID=7,keyID=groupid,languageID=lang,text=groupids[groupid]['name'][lang])
     trans.commit()

--- a/tableloader/tableFunctions/groups.py
+++ b/tableloader/tableFunctions/groups.py
@@ -1,39 +1,39 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
+import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath,language='en'):
     invGroups = Table('invGroups',metadata)
     trnTranslations = Table('trnTranslations',metadata)
-    print "Importing Groups"
-    print "opening Yaml"
+    print("Importing Groups")
+    print("opening Yaml")
     with open(os.path.join(sourcePath,'fsd','groupIDs.yaml'),'r') as yamlstream:
         trans = connection.begin()
         groupids=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for groupid in groupids:
             connection.execute(invGroups.insert(),
                             groupID=groupid,
                             categoryID=groupids[groupid].get('categoryID',0),
-                            groupName=groupids[groupid].get('name',{}).get(language,'').decode('utf-8'),
+                            groupName=groupids[groupid].get('name',{}).get(language,''),
                             iconID=groupids[groupid].get('iconID'),
                             useBasePrice=groupids[groupid].get('useBasePrice'),
                             anchored=groupids[groupid].get('anchored',0),
                             anchorable=groupids[groupid].get('anchorable',0),
                             fittableNonSingleton=groupids[groupid].get('fittableNonSingleton',0),
                             published=groupids[groupid].get('published',0))
-            if (groupids[groupid].has_key('name')):
+            if ('name' in groupids[groupid]):
                 for lang in groupids[groupid]['name']:
-                    connection.execute(trnTranslations.insert(),tcID=7,keyID=groupid,languageID=lang,text=groupids[groupid]['name'][lang].decode('utf-8'));
+                    connection.execute(trnTranslations.insert(),tcID=7,keyID=groupid,languageID=lang,text=groupids[groupid]['name'][lang])
     trans.commit()

--- a/tableloader/tableFunctions/icons.py
+++ b/tableloader/tableFunctions/icons.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
-import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
 
 import os
 import sys
-importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):

--- a/tableloader/tableFunctions/icons.py
+++ b/tableloader/tableFunctions/icons.py
@@ -1,26 +1,26 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
+import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):
     eveIcons = Table('eveIcons',metadata)
-    print "Importing Icons"
-    print "Opening Yaml"
+    print("Importing Icons")
+    print("Opening Yaml")
     with open(os.path.join(sourcePath,'fsd','iconIDs.yaml'),'r') as yamlstream:
         trans = connection.begin()
         icons=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for icon in icons:
             connection.execute(eveIcons.insert(),
                             iconID=icon,

--- a/tableloader/tableFunctions/marketGroups.py
+++ b/tableloader/tableFunctions/marketGroups.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
@@ -36,13 +33,13 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                             hasTypes=marketgroups[marketgroupid].get('hasTypes',False)
             )
             
-            if ('nameID' in marketgroups[marketgroupid]):
+            if 'nameID' in marketgroups[marketgroupid]:
                 for lang in marketgroups[marketgroupid]['nameID']:
                     try:
                         connection.execute(trnTranslations.insert(),tcID=36,keyID=marketgroupid,languageID=lang,text=marketgroups[marketgroupid]['nameID'][lang])
                     except:                        
                         print('{} {} has a category problem'.format(categoryid,lang))
-            if ('descriptionID' in marketgroups[marketgroupid]):
+            if 'descriptionID' in marketgroups[marketgroupid]:
                 for lang in marketgroups[marketgroupid]['descriptionID']:
                     try:
                         connection.execute(trnTranslations.insert(),tcID=37,keyID=marketgroupid,languageID=lang,text=marketgroups[marketgroupid]['descriptionID'][lang])

--- a/tableloader/tableFunctions/marketGroups.py
+++ b/tableloader/tableFunctions/marketGroups.py
@@ -1,51 +1,51 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 def importyaml(connection,metadata,sourcePath,language='en'):
-    print "Importing marketGroups"
+    print("Importing marketGroups")
     invMarketGroups = Table('invMarketGroups',metadata)
     trnTranslations = Table('trnTranslations',metadata)
     
-    print "opening Yaml"
+    print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','marketGroups.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         marketgroups=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for marketgroupid in marketgroups:
             connection.execute(invMarketGroups.insert(),
                             marketGroupID=marketgroupid,
                             parentGroupID=marketgroups[marketgroupid].get('parentGroupID',None),
-                            marketGroupName=marketgroups[marketgroupid].get('nameID',{}).get(language,'').decode('utf-8'),
-                            description=marketgroups[marketgroupid].get('descriptionID',{}).get(language,'').decode('utf-8'),
+                            marketGroupName=marketgroups[marketgroupid].get('nameID',{}).get(language,''),
+                            description=marketgroups[marketgroupid].get('descriptionID',{}).get(language,''),
                             iconID=marketgroups[marketgroupid].get('iconID'),
                             hasTypes=marketgroups[marketgroupid].get('hasTypes',False)
             )
             
-            if (marketgroups[marketgroupid].has_key('nameID')):
+            if ('nameID' in marketgroups[marketgroupid]):
                 for lang in marketgroups[marketgroupid]['nameID']:
                     try:
-                        connection.execute(trnTranslations.insert(),tcID=36,keyID=marketgroupid,languageID=lang,text=marketgroups[marketgroupid]['nameID'][lang].decode('utf-8'));
+                        connection.execute(trnTranslations.insert(),tcID=36,keyID=marketgroupid,languageID=lang,text=marketgroups[marketgroupid]['nameID'][lang])
                     except:                        
-                        print '{} {} has a category problem'.format(categoryid,lang)
-            if (marketgroups[marketgroupid].has_key('descriptionID')):
+                        print('{} {} has a category problem'.format(categoryid,lang))
+            if ('descriptionID' in marketgroups[marketgroupid]):
                 for lang in marketgroups[marketgroupid]['descriptionID']:
                     try:
-                        connection.execute(trnTranslations.insert(),tcID=37,keyID=marketgroupid,languageID=lang,text=marketgroups[marketgroupid]['descriptionID'][lang].decode('utf-8'));
+                        connection.execute(trnTranslations.insert(),tcID=37,keyID=marketgroupid,languageID=lang,text=marketgroups[marketgroupid]['descriptionID'][lang])
                     except:                        
-                        print '{} {} has a category problem'.format(categoryid,lang)
+                        print('{} {} has a category problem'.format(categoryid,lang))
     trans.commit()

--- a/tableloader/tableFunctions/metaGroups.py
+++ b/tableloader/tableFunctions/metaGroups.py
@@ -1,14 +1,11 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
@@ -34,13 +31,13 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                             description=metagroups[metagroupid].get('descriptionID',{}).get(language,'')
             )
             
-            if ('nameID' in metagroups[metagroupid]):
+            if 'nameID' in metagroups[metagroupid]:
                 for lang in metagroups[metagroupid]['nameID']:
                     try:
                         connection.execute(trnTranslations.insert(),tcID=34,keyID=metagroupid,languageID=lang,text=metagroups[metagroupid]['nameID'][lang])
                     except:                        
                         print('{} {} has a category problem'.format(categoryid,lang))
-            if ('descriptionID' in metagroups[metagroupid]):
+            if 'descriptionID' in metagroups[metagroupid]:
                 for lang in metagroups[metagroupid]['descriptionID']:
                     try:
                         connection.execute(trnTranslations.insert(),tcID=35,keyID=metagroupid,languageID=lang,text=metagroups[metagroupid]['descriptionID'][lang])

--- a/tableloader/tableFunctions/metaGroups.py
+++ b/tableloader/tableFunctions/metaGroups.py
@@ -1,49 +1,49 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from sqlalchemy import Table
 
 from yaml import load
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 
 def importyaml(connection,metadata,sourcePath,language='en'):
-    print "Importing metaGroups"
+    print("Importing metaGroups")
     invMetaGroups = Table('invMetaGroups',metadata)
     trnTranslations = Table('trnTranslations',metadata)
     
-    print "opening Yaml"
+    print("opening Yaml")
         
     trans = connection.begin()
     with open(os.path.join(sourcePath,'fsd','metaGroups.yaml'),'r') as yamlstream:
-        print "importing"
+        print("importing")
         metagroups=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for metagroupid in metagroups:
             connection.execute(invMetaGroups.insert(),
                             metaGroupID=metagroupid,
-                            metaGroupName=metagroups[metagroupid].get('nameID',{}).get(language,'').decode('utf-8'),
+                            metaGroupName=metagroups[metagroupid].get('nameID',{}).get(language,''),
                             iconID=metagroups[metagroupid].get('iconID'),
-                            description=metagroups[metagroupid].get('descriptionID',{}).get(language,'').decode('utf-8')
+                            description=metagroups[metagroupid].get('descriptionID',{}).get(language,'')
             )
             
-            if (metagroups[metagroupid].has_key('nameID')):
+            if ('nameID' in metagroups[metagroupid]):
                 for lang in metagroups[metagroupid]['nameID']:
                     try:
-                        connection.execute(trnTranslations.insert(),tcID=34,keyID=metagroupid,languageID=lang,text=metagroups[metagroupid]['nameID'][lang].decode('utf-8'));
+                        connection.execute(trnTranslations.insert(),tcID=34,keyID=metagroupid,languageID=lang,text=metagroups[metagroupid]['nameID'][lang])
                     except:                        
-                        print '{} {} has a category problem'.format(categoryid,lang)
-            if (metagroups[metagroupid].has_key('descriptionID')):
+                        print('{} {} has a category problem'.format(categoryid,lang))
+            if ('descriptionID' in metagroups[metagroupid]):
                 for lang in metagroups[metagroupid]['descriptionID']:
                     try:
-                        connection.execute(trnTranslations.insert(),tcID=35,keyID=metagroupid,languageID=lang,text=metagroups[metagroupid]['descriptionID'][lang].decode('utf-8'));
+                        connection.execute(trnTranslations.insert(),tcID=35,keyID=metagroupid,languageID=lang,text=metagroups[metagroupid]['descriptionID'][lang])
                     except:                        
-                        print '{} {} has a category problem'.format(categoryid,lang)
+                        print('{} {} has a category problem'.format(categoryid,lang))
     trans.commit()

--- a/tableloader/tableFunctions/skins.py
+++ b/tableloader/tableFunctions/skins.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
-import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
 
 import os
 import sys
-importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):

--- a/tableloader/tableFunctions/skins.py
+++ b/tableloader/tableFunctions/skins.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
+import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath):
@@ -20,11 +20,11 @@ def importyaml(connection,metadata,sourcePath):
     skinShip = Table('skinShip',metadata)            
                 
     trans = connection.begin()
-    print "Importing Skins"
-    print "opening Yaml1"
+    print("Importing Skins")
+    print("opening Yaml1")
     with open(os.path.join(sourcePath,'fsd','skins.yaml'),'r') as yamlstream:
         skins=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for skinid in skins:
             connection.execute(skins_table.insert(),
                             skinID=skinid,
@@ -36,19 +36,19 @@ def importyaml(connection,metadata,sourcePath):
                                 typeID=ship)
 
 
-    print "opening Yaml2"
+    print("opening Yaml2")
     with open(os.path.join(sourcePath,'fsd','skinLicenses.yaml'),'r') as yamlstream:
         skinlicenses=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for licenseid in skinlicenses:
             connection.execute(skinLicense.insert(),
                                 licenseTypeID=licenseid,
                                 duration=skinlicenses[licenseid]['duration'],
                                 skinID=skinlicenses[licenseid]['skinID'])
-    print "opening Yaml3"
+    print("opening Yaml3")
     with open(os.path.join(sourcePath,'fsd','skinMaterials.yaml'),'r') as yamlstream:
         skinmaterials=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for materialid in skinmaterials:
             connection.execute(skinMaterials.insert(),
                                 skinMaterialID=materialid,

--- a/tableloader/tableFunctions/types.py
+++ b/tableloader/tableFunctions/types.py
@@ -18,6 +18,7 @@ def importyaml(connection,metadata,sourcePath,language='en'):
     trnTranslations = Table('trnTranslations',metadata)
     certMasteries = Table('certMasteries',metadata)
     invTraits = Table('invTraits',metadata)
+    invMetaTypes = Table('invMetaTypes',metadata)
     print("Importing Types")
     print("Opening Yaml")
     with open(os.path.join(sourcePath,'fsd','typeIDs.yaml'),'r') as yamlstream:
@@ -89,4 +90,6 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                         traitid=result.inserted_primary_key
                         for languageid in trait.get('bonusText',{}):
                             connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid,text=trait['bonusText'][languageid])
+            if 'metaGroupID' in typeids[typeid] or 'variationParentTypeID' in typeids[typeid]:
+                connection.execute(invMetaTypes.insert(),typeID=typeid,metaGroupID=typeids[typeid].get('metaGroupID'),parentTypeID=typeids[typeid].get('variationParentTypeID'))
     trans.commit()

--- a/tableloader/tableFunctions/types.py
+++ b/tableloader/tableFunctions/types.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
-import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")
 
 import os
 import sys
-importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath,language='en'):
@@ -42,20 +39,20 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                             graphicID=typeids[typeid].get('graphicID',0),
                             iconID=typeids[typeid].get('iconID'),
                             soundID=typeids[typeid].get('soundID'))
-            if  "masteries" in typeids[typeid]:
+            if 'masteries' in typeids[typeid]:
                 for level in typeids[typeid]["masteries"]:
                     for cert in typeids[typeid]["masteries"][level]:
                         connection.execute(certMasteries.insert(),
                                             typeID=typeid,
                                             masteryLevel=level,
                                             certID=cert)
-            if ('name' in typeids[typeid]):
+            if 'name' in typeids[typeid]:
                 for lang in typeids[typeid]['name']:
                     connection.execute(trnTranslations.insert(),tcID=8,keyID=typeid,languageID=lang,text=typeids[typeid]['name'][lang])
-            if ('description' in typeids[typeid]):
+            if 'description' in typeids[typeid]:
                 for lang in typeids[typeid]['description']:
                     connection.execute(trnTranslations.insert(),tcID=33,keyID=typeid,languageID=lang,text=typeids[typeid]['description'][lang])
-            if ('traits' in typeids[typeid]):
+            if 'traits' in typeids[typeid]:
                 if 'types' in typeids[typeid]['traits']:
                     for skill in typeids[typeid]['traits']['types']:
                         for trait in typeids[typeid]['traits']['types'][skill]:
@@ -93,3 +90,4 @@ def importyaml(connection,metadata,sourcePath,language='en'):
             if 'metaGroupID' in typeids[typeid] or 'variationParentTypeID' in typeids[typeid]:
                 connection.execute(invMetaTypes.insert(),typeID=typeid,metaGroupID=typeids[typeid].get('metaGroupID'),parentTypeID=typeids[typeid].get('variationParentTypeID'))
     trans.commit()
+

--- a/tableloader/tableFunctions/types.py
+++ b/tableloader/tableFunctions/types.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 from yaml import load, dump
+import importlib
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+importlib.reload(sys)
 from sqlalchemy import Table
 
 def importyaml(connection,metadata,sourcePath,language='en'):
@@ -18,18 +18,18 @@ def importyaml(connection,metadata,sourcePath,language='en'):
     trnTranslations = Table('trnTranslations',metadata)
     certMasteries = Table('certMasteries',metadata)
     invTraits = Table('invTraits',metadata)
-    print "Importing Types"
-    print "Opening Yaml"
+    print("Importing Types")
+    print("Opening Yaml")
     with open(os.path.join(sourcePath,'fsd','typeIDs.yaml'),'r') as yamlstream:
         trans = connection.begin()
         typeids=load(yamlstream,Loader=SafeLoader)
-        print "Yaml Processed into memory"
+        print("Yaml Processed into memory")
         for typeid in typeids:
             connection.execute(invTypes.insert(),
                             typeID=typeid,
                             groupID=typeids[typeid].get('groupID',0),
-                            typeName=typeids[typeid].get('name',{}).get(language,'').decode('utf-8'),
-                            description=typeids[typeid].get('description',{}).get(language,'').decode('utf-8'),
+                            typeName=typeids[typeid].get('name',{}).get(language,''),
+                            description=typeids[typeid].get('description',{}).get(language,''),
                             mass=typeids[typeid].get('mass',0),
                             volume=typeids[typeid].get('volume',0),
                             capacity=typeids[typeid].get('capacity',0),
@@ -41,21 +41,21 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                             graphicID=typeids[typeid].get('graphicID',0),
                             iconID=typeids[typeid].get('iconID'),
                             soundID=typeids[typeid].get('soundID'))
-            if  typeids[typeid].has_key("masteries"):
+            if  "masteries" in typeids[typeid]:
                 for level in typeids[typeid]["masteries"]:
                     for cert in typeids[typeid]["masteries"][level]:
                         connection.execute(certMasteries.insert(),
                                             typeID=typeid,
                                             masteryLevel=level,
                                             certID=cert)
-            if (typeids[typeid].has_key('name')):
+            if ('name' in typeids[typeid]):
                 for lang in typeids[typeid]['name']:
-                    connection.execute(trnTranslations.insert(),tcID=8,keyID=typeid,languageID=lang.decode('utf-8'),text=typeids[typeid]['name'][lang].decode('utf-8'))
-            if (typeids[typeid].has_key('description')):
+                    connection.execute(trnTranslations.insert(),tcID=8,keyID=typeid,languageID=lang,text=typeids[typeid]['name'][lang])
+            if ('description' in typeids[typeid]):
                 for lang in typeids[typeid]['description']:
-                    connection.execute(trnTranslations.insert(),tcID=33,keyID=typeid,languageID=lang.decode('utf-8'),text=typeids[typeid]['description'][lang].decode('utf-8'))
-            if (typeids[typeid].has_key('traits')):
-                if typeids[typeid]['traits'].has_key('types'):
+                    connection.execute(trnTranslations.insert(),tcID=33,keyID=typeid,languageID=lang,text=typeids[typeid]['description'][lang])
+            if ('traits' in typeids[typeid]):
+                if 'types' in typeids[typeid]['traits']:
                     for skill in typeids[typeid]['traits']['types']:
                         for trait in typeids[typeid]['traits']['types'][skill]:
                             result=connection.execute(invTraits.insert(),
@@ -66,8 +66,8 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                                                 unitID=trait.get('unitID'))
                             traitid=result.inserted_primary_key
                             for languageid in trait.get('bonusText',{}):
-                                connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid.decode('utf-8'),text=trait['bonusText'][languageid].decode('utf-8'))
-                if typeids[typeid]['traits'].has_key('roleBonuses'):
+                                connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid,text=trait['bonusText'][languageid])
+                if 'roleBonuses' in typeids[typeid]['traits']:
                     for trait in typeids[typeid]['traits']['roleBonuses']:
                         result=connection.execute(invTraits.insert(),
                                 typeID=typeid,
@@ -77,8 +77,8 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                                 unitID=trait.get('unitID'))
                         traitid=result.inserted_primary_key
                         for languageid in trait.get('bonusText',{}):
-                            connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid.decode('utf-8'),text=trait['bonusText'][languageid].decode('utf-8'))
-                if typeids[typeid]['traits'].has_key('miscBonuses'):
+                            connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid,text=trait['bonusText'][languageid])
+                if 'miscBonuses' in typeids[typeid]['traits']:
                     for trait in typeids[typeid]['traits']['miscBonuses']:
                         result=connection.execute(invTraits.insert(),
                                 typeID=typeid,
@@ -88,5 +88,5 @@ def importyaml(connection,metadata,sourcePath,language='en'):
                                 unitID=trait.get('unitID'))
                         traitid=result.inserted_primary_key
                         for languageid in trait.get('bonusText',{}):
-                            connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid.decode('utf-8'),text=trait['bonusText'][languageid].decode('utf-8'))
+                            connection.execute(trnTranslations.insert(),tcID=1002,keyID=traitid[0],languageID=languageid,text=trait['bonusText'][languageid])
     trans.commit()

--- a/tableloader/tableFunctions/universe.py
+++ b/tableloader/tableFunctions/universe.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import sys
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 from yaml import load, dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print "Using CSafeLoader"
+	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
-	print "Using Python SafeLoader"
+	print("Using Python SafeLoader")
 
 import os
 from sqlalchemy import Table,select
@@ -27,7 +27,7 @@ def grouplookup(connection,metadata,typeid):
                 invTypes.select().where( invTypes.c.typeID == typeid )
             ).fetchall()[0]['groupID']
     except:
-        print typeid
+        print(typeid)
         exit()
     typeidcache[typeid]=groupid
     return groupid
@@ -44,13 +44,13 @@ def get_distance_squared(c1, c2):
 def get_sorted_objects(planet, key):
     with_radius = [(get_distance_squared(obj, planet), obj_id)
                    for (obj_id, obj)
-                   in planet.get(key, {}).items()]
+                   in list(planet.get(key, {}).items())]
     with_radius.sort()
     return [obj_id for (radius, obj_id) in with_radius]
 
 def importyaml(connection,metadata,sourcePath):
 
-    print "Importing Universe Data"
+    print("Importing Universe Data")
 
     mapCelestialStatistics =  Table('mapCelestialStatistics', metadata) #done
     mapConstellations =  Table('mapConstellations', metadata) # done
@@ -79,14 +79,14 @@ def importyaml(connection,metadata,sourcePath):
     regions=glob.glob(os.path.join(sourcePath,'fsd','universe','*','*','region.staticdata'))
     for regionfile in regions:
         head, tail = os.path.split(regionfile)
-        print "Importing Region {}".format(head)
+        print("Importing Region {}".format(head))
         trans = connection.begin()
         with open(regionfile,'r') as yamlstream:
             region=load(yamlstream,Loader=SafeLoader)
         regionname=connection.execute(
             invNames.select().where( invNames.c.itemID == region['regionID'] )
         ).fetchall()[0]['itemName']
-        print "Region {}".format(regionname)
+        print("Region {}".format(regionname))
         connection.execute(mapRegions.insert(),
                             regionID=region['regionID'],
                             regionName=regionname,
@@ -116,9 +116,9 @@ def importyaml(connection,metadata,sourcePath):
         if  region.get('wormholeClassID'):
             connection.execute(mapLocationWormholeClasses.insert(),
                                 locationID=region['regionID'],
-                                wormholeClassID=region['wormholeClassID']);
+                                wormholeClassID=region['wormholeClassID'])
                             
-        print "Importing Constellations."
+        print("Importing Constellations.")
         constellations=glob.glob(os.path.join(head,'*','constellation.staticdata'))
         for constellationfile in constellations:
             chead, tail = os.path.split(constellationfile)
@@ -127,7 +127,7 @@ def importyaml(connection,metadata,sourcePath):
             constellationname=connection.execute(
                 invNames.select().where( invNames.c.itemID == constellation['constellationID'] )
             ).fetchall()[0]['itemName']
-            print "Constellation {}".format(constellationname)
+            print("Constellation {}".format(constellationname))
             connection.execute(mapConstellations.insert(),
                                 regionID=region['regionID'],
                                 constellationID=constellation['constellationID'],
@@ -157,17 +157,17 @@ def importyaml(connection,metadata,sourcePath):
             if  constellation.get('wormholeClassID'):
                 connection.execute(mapLocationWormholeClasses.insert(),
                                 locationID=constellation['constellationID'],
-                                wormholeClassID=constellation['wormholeClassID']);
+                                wormholeClassID=constellation['wormholeClassID'])
 
             systems=glob.glob(os.path.join(chead,'*','solarsystem.staticdata'))
-            print "Importing Systems"
+            print("Importing Systems")
             for systemfile in systems:
                 with open(systemfile,'r') as yamlstream:
                     system=load(yamlstream,Loader=SafeLoader)
                 systemname=connection.execute(
                     invNames.select().where( invNames.c.itemID == system['solarSystemID'] )
                 ).fetchall()[0]['itemName']
-                print "System {}".format(systemname)
+                print("System {}".format(systemname))
                 if 'star' in system:
                     starname=connection.execute(
                         invNames.select().where( invNames.c.itemID == system['star']['id'] )
@@ -229,10 +229,10 @@ def importyaml(connection,metadata,sourcePath):
                 if  system.get('wormholeClassID'):
                     connection.execute(mapLocationWormholeClasses.insert(),
                                 locationID=system['solarSystemID'],
-                                wormholeClassID=system['wormholeClassID']);
+                                wormholeClassID=system['wormholeClassID'])
 
 
-                print "Importing Statistics"
+                print("Importing Statistics")
                 if 'star' in system:
                     sstats=system['star'].get('statistics',{})
                     sstats['celestialID']=system['star']['id']
@@ -249,11 +249,11 @@ def importyaml(connection,metadata,sourcePath):
                         mstats=system['planets'][planet]['moons'][moon].get('statistics',{})
                         mstats['celestialID']=moon
                         connection.execute(mapCelestialStatistics.insert(),mstats)
-                print "Importing Stargates"
+                print("Importing Stargates")
                 for stargate in system.get('stargates',[]):
                     jump={'stargateID':stargate,'destinationID':system['stargates'][stargate]['destination']}
                     connection.execute(mapJumps.insert(),jump)
-                print "Importing to mapDenormalize"
+                print("Importing to mapDenormalize")
                 connection.execute(mapDenormalize.insert(),
                                         itemID=system['solarSystemID'],
                                         typeID=5,

--- a/tableloader/tableFunctions/universe.py
+++ b/tableloader/tableFunctions/universe.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
-import importlib
-importlib.reload(sys)
 from yaml import load, dump
 try:
 	from yaml import CSafeLoader as SafeLoader
-	print("Using CSafeLoader")
 except ImportError:
 	from yaml import SafeLoader
 	print("Using Python SafeLoader")

--- a/tableloader/tableFunctions/volumes.py
+++ b/tableloader/tableFunctions/volumes.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-reload(sys)
-sys.setdefaultencoding("utf-8")
+import importlib
+importlib.reload(sys)
 import yaml
 from sqlalchemy import Table,literal_column,select
 import csv

--- a/tableloader/tableFunctions/volumes.py
+++ b/tableloader/tableFunctions/volumes.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
 import os
-import importlib
-importlib.reload(sys)
 import yaml
 from sqlalchemy import Table,literal_column,select
 import csv

--- a/tableloader/tables.py
+++ b/tableloader/tables.py
@@ -8,1151 +8,1011 @@ from sqlalchemy import *
 def metadataCreator(schema):
 
 
-    metadata = MetaData(schema=schema)
-
-
-    agtAgentTypes =  Table('agtAgentTypes', metadata,
-        Column('agentTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-                Column('agentType', VARCHAR(length=50))
-        )
-
-
-    agtAgents =  Table('agtAgents', metadata,
-            Column('agentID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('divisionID', INTEGER()),
-            Column('corporationID', INTEGER(),index=True),
-            Column('locationID', INTEGER(),index=True),
-            Column('level', INTEGER()),
-            Column('quality', INTEGER()),
-            Column('agentTypeID', INTEGER()),
-            Column('isLocator', Boolean(name='aa_isloc')),
-            schema=schema
-    )
-
-
-    agtResearchAgents =  Table('agtResearchAgents', metadata,
-           Column('agentID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
-            schema=schema
-
-
-    )
-
-
-    certCerts =  Table('certCerts', metadata,
-            Column('certID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('description',UnicodeText()),
-            Column('groupID', INTEGER()),
-            Column('name', VARCHAR(length=255)),
-            schema=schema
-
-
-    )
-
-
-    certMasteries =  Table('certMasteries', metadata,
-            Column('typeID', INTEGER()),
-            Column('masteryLevel', INTEGER()),
-            Column('certID', INTEGER()),
-            schema=schema
-
-    )
-
-
-    certSkills =  Table('certSkills', metadata,
-            Column('certID', INTEGER()),
-            Column('skillID', INTEGER(),index=True),
-            Column('certLevelInt', INTEGER()),
-            Column('skillLevel', INTEGER()),
-            Column('certLevelText', VARCHAR(length=8)),
-            schema=schema
-
-
-    )
-
-
-    chrAncestries =  Table('chrAncestries', metadata,
-            Column('ancestryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('ancestryName', VARCHAR(length=100)),
-            Column('bloodlineID', INTEGER()),
-            Column('description', VARCHAR(length=1000)),
-            Column('perception', INTEGER()),
-            Column('willpower', INTEGER()),
-            Column('charisma', INTEGER()),
-            Column('memory', INTEGER()),
-            Column('intelligence', INTEGER()),
-            Column('iconID', INTEGER()),
-            Column('shortDescription', VARCHAR(length=500)),
-            schema=schema
-
-
-    )
-
-
-    chrAttributes =  Table('chrAttributes', metadata,
-            Column('attributeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('attributeName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('iconID', INTEGER()),
-            Column('shortDescription', VARCHAR(length=500)),
-            Column('notes', VARCHAR(length=500)),
-            schema=schema
-
-
-    )
-
-
-    chrBloodlines =  Table('chrBloodlines', metadata,
-            Column('bloodlineID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('bloodlineName', VARCHAR(length=100)),
-            Column('raceID', INTEGER()),
-            Column('description', VARCHAR(length=1000)),
-            Column('maleDescription', VARCHAR(length=1000)),
-            Column('femaleDescription', VARCHAR(length=1000)),
-            Column('shipTypeID', INTEGER()),
-            Column('corporationID', INTEGER()),
-            Column('perception', INTEGER()),
-            Column('willpower', INTEGER()),
-            Column('charisma', INTEGER()),
-            Column('memory', INTEGER()),
-            Column('intelligence', INTEGER()),
-            Column('iconID', INTEGER()),
-            Column('shortDescription', VARCHAR(length=500)),
-            Column('shortMaleDescription', VARCHAR(length=500)),
-            Column('shortFemaleDescription', VARCHAR(length=500)),
-            schema=schema
-
-
-    )
-
-
-    chrFactions =  Table('chrFactions', metadata,
-            Column('factionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('factionName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('raceIDs', INTEGER()),
-            Column('solarSystemID', INTEGER()),
-            Column('corporationID', INTEGER()),
-            Column('sizeFactor', FLOAT()),
-            Column('stationCount', INTEGER()),
-            Column('stationSystemCount', INTEGER()),
-            Column('militiaCorporationID', INTEGER()),
-            Column('iconID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    chrRaces =  Table('chrRaces', metadata,
-            Column('raceID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('raceName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('iconID', INTEGER()),
-            Column('shortDescription', VARCHAR(length=500)),
-            schema=schema
-
-
-    )
-
-
-    crpActivities =  Table('crpActivities', metadata,
-            Column('activityID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('activityName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            schema=schema
-
-
-    )
-
-
-    crpNPCCorporationDivisions =  Table('crpNPCCorporationDivisions', metadata,
-            Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('divisionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('size', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    crpNPCCorporationResearchFields =  Table('crpNPCCorporationResearchFields', metadata,
-            Column('skillID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            schema=schema
-
-
-    )
-
-
-    crpNPCCorporationTrades =  Table('crpNPCCorporationTrades', metadata,
-            Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            schema=schema
-
-
-    )
-
-
-    crpNPCCorporations =  Table('crpNPCCorporations', metadata,
-            Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('size', CHAR(length=1)),
-            Column('extent', CHAR(length=1)),
-            Column('solarSystemID', INTEGER()),
-            Column('investorID1', INTEGER()),
-            Column('investorShares1', INTEGER()),
-            Column('investorID2', INTEGER()),
-            Column('investorShares2', INTEGER()),
-            Column('investorID3', INTEGER()),
-            Column('investorShares3', INTEGER()),
-            Column('investorID4', INTEGER()),
-            Column('investorShares4', INTEGER()),
-            Column('friendID', INTEGER()),
-            Column('enemyID', INTEGER()),
-            Column('publicShares', INTEGER()),
-            Column('initialPrice', INTEGER()),
-            Column('minSecurity', FLOAT()),
-            Column('scattered', Boolean(name='cnpcc_scatt')),
-            Column('fringe', INTEGER()),
-            Column('corridor', INTEGER()),
-            Column('hub', INTEGER()),
-            Column('border', INTEGER()),
-            Column('factionID', INTEGER()),
-            Column('sizeFactor', FLOAT()),
-            Column('stationCount', INTEGER()),
-            Column('stationSystemCount', INTEGER()),
-            Column('description', VARCHAR(length=4000)),
-            Column('iconID', INTEGER()),
-            schema=schema
-
-
-            )
-
-
-    crpNPCDivisions =  Table('crpNPCDivisions', metadata,
-            Column('divisionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('divisionName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('leaderType', VARCHAR(length=100)),
-            schema=schema
-
-
-    )
-
-
-    dgmAttributeCategories =  Table('dgmAttributeCategories', metadata,
-            Column('categoryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('categoryName', VARCHAR(length=50)),
-            Column('categoryDescription', VARCHAR(length=200)),
-            schema=schema
-
-
-    )
-
-
-    dgmAttributeTypes =  Table('dgmAttributeTypes', metadata,
-            Column('attributeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('attributeName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('iconID', INTEGER()),
-            Column('defaultValue', FLOAT()),
-            Column('published', Boolean(name='dat_pub')),
-            Column('displayName', VARCHAR(length=150)),
-            Column('unitID', INTEGER()),
-            Column('stackable', Boolean(name='dat_stack')),
-            Column('highIsGood', Boolean(name='dat_hig')),
-            Column('categoryID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    dgmEffects =  Table('dgmEffects', metadata,
-            Column('effectID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('effectName', VARCHAR(length=400)),
-            Column('effectCategory', INTEGER()),
-            Column('preExpression', INTEGER()),
-            Column('postExpression', INTEGER()),
-            Column('description', VARCHAR(length=1000)),
-            Column('guid', VARCHAR(length=60)),
-            Column('iconID', INTEGER()),
-            Column('isOffensive', Boolean(name='de_offense')),
-            Column('isAssistance', Boolean(name='de_assist')),
-            Column('durationAttributeID', INTEGER()),
-            Column('trackingSpeedAttributeID', INTEGER()),
-            Column('dischargeAttributeID', INTEGER()),
-            Column('rangeAttributeID', INTEGER()),
-            Column('falloffAttributeID', INTEGER()),
-            Column('disallowAutoRepeat', Boolean(name='de_disallowar')),
-            Column('published', Boolean(name='de_published')),
-            Column('displayName', VARCHAR(length=100)),
-            Column('isWarpSafe', Boolean(name='de_warpsafe')),
-            Column('rangeChance', Boolean(name='de_rangechance')),
-            Column('electronicChance', Boolean(name='de_elecchance')),
-            Column('propulsionChance', Boolean(name='de_propchance')),
-            Column('distribution', INTEGER()),
-            Column('sfxName', VARCHAR(length=20)),
-            Column('npcUsageChanceAttributeID', INTEGER()),
-            Column('npcActivationChanceAttributeID', INTEGER()),
-            Column('fittingUsageChanceAttributeID', INTEGER()),
-            Column('modifierInfo',UnicodeText()),
-            schema=schema
-
-
-    )
-
-
-    dgmExpressions =  Table('dgmExpressions', metadata,
-            Column('expressionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('operandID', INTEGER()),
-            Column('arg1', INTEGER()),
-            Column('arg2', INTEGER()),
-            Column('expressionValue', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('expressionName', VARCHAR(length=500)),
-            Column('expressionTypeID', INTEGER()),
-            Column('expressionGroupID', INTEGER()),
-            Column('expressionAttributeID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    dgmTypeAttributes =  Table('dgmTypeAttributes', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('attributeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
-            Column('valueInt', INTEGER()),
-            Column('valueFloat', FLOAT()),
-            schema=schema
-
-
-    )
-
-
-    dgmTypeEffects =  Table('dgmTypeEffects', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('effectID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('isDefault', Boolean(name='dte_default')),
-            schema=schema
-
-
-    )
-
-
-    eveGraphics =  Table('eveGraphics', metadata,
-            Column('graphicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('sofFactionName', VARCHAR(length=100)),
-            Column('graphicFile', VARCHAR(length=100)),
-            Column('sofHullName', VARCHAR(length=100)),
-            Column('sofRaceName', VARCHAR(length=100)),
-            Column('description',UnicodeText()),
-            schema=schema
-
-
-    )
-
-
-    eveIcons =  Table('eveIcons', metadata,
-            Column('iconID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('iconFile', VARCHAR(length=500)),
-            Column('description',UnicodeText()),
-            schema=schema
-
-
-    )
-
-
-    eveUnits =  Table('eveUnits', metadata,
-            Column('unitID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('unitName', VARCHAR(length=100)),
-            Column('displayName', VARCHAR(length=50)),
-            Column('description', VARCHAR(length=1000)),
-            schema=schema
-
-
-    )
-
-
-    industryActivity =  Table('industryActivity', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('activityID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
-            Column('time', INTEGER()),
-            schema=schema
-    )
-
-
-    industryActivityMaterials =  Table('industryActivityMaterials', metadata,
-            Column('typeID', INTEGER(),index=True),
-            Column('activityID', INTEGER()),
-            Column('materialTypeID', INTEGER()),
-            Column('quantity', INTEGER()),
-            schema=schema
-    )
-    Index('industryActivityMaterials_idx1',industryActivityMaterials.c.typeID,industryActivityMaterials.c.activityID)
-
-
-    industryActivityProbabilities =  Table('industryActivityProbabilities', metadata,
-            Column('typeID', INTEGER(),index=True),
-            Column('activityID', INTEGER()),
-            Column('productTypeID', INTEGER(),index=True),
-            Column('probability', DECIMAL(precision=3, scale=2)),
-            schema=schema
-
-
-    )
-
-
-    industryActivityProducts =  Table('industryActivityProducts', metadata,
-            Column('typeID', INTEGER(),index=True),
-            Column('activityID', INTEGER()),
-            Column('productTypeID', INTEGER(),index=True),
-            Column('quantity', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    industryActivityRaces =  Table('industryActivityRaces', metadata,
-            Column('typeID', INTEGER(),index=True),
-            Column('activityID', INTEGER()),
-            Column('productTypeID', INTEGER(),index=True),
-            Column('raceID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    industryActivitySkills =  Table('industryActivitySkills', metadata,
-            Column('typeID', INTEGER(),index=True),
-            Column('activityID', INTEGER()),
-            Column('skillID', INTEGER(),index=True),
-            Column('level', INTEGER()),
-            schema=schema
-    )
-    Index('industryActivitySkills_idx1',industryActivitySkills.c.typeID,industryActivitySkills.c.activityID)
-
-    industryBlueprints =  Table('industryBlueprints', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('maxProductionLimit', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invCategories =  Table('invCategories', metadata,
-            Column('categoryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('categoryName', VARCHAR(length=100)),
-            Column('iconID', INTEGER()),
-            Column('published', Boolean(name='invcat_published')),
-            schema=schema
-
-
-    )
-
-
-    invContrabandTypes =  Table('invContrabandTypes', metadata,
-            Column('factionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
-            Column('standingLoss', FLOAT(precision=53)),
-            Column('confiscateMinSec', FLOAT(precision=53)),
-            Column('fineByValue', FLOAT(precision=53)),
-            Column('attackMinSec', FLOAT(precision=53)),
-            schema=schema
-
-
-    )
-
-
-    invControlTowerResourcePurposes =  Table('invControlTowerResourcePurposes', metadata,
-            Column('purpose', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('purposeText', VARCHAR(length=100)),
-            schema=schema
-
-
-    )
-
-
-    invControlTowerResources =  Table('invControlTowerResources', metadata,
-            Column('controlTowerTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('resourceTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('purpose', INTEGER()),
-            Column('quantity', INTEGER()),
-            Column('minSecurityLevel', FLOAT(precision=53)),
-            Column('factionID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invFlags =  Table('invFlags', metadata,
-            Column('flagID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('flagName', VARCHAR(length=200)),
-            Column('flagText', VARCHAR(length=100)),
-            Column('orderID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invGroups =  Table('invGroups', metadata,
-            Column('groupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('categoryID', INTEGER(),index=True),
-            Column('groupName', VARCHAR(length=100)),
-            Column('iconID', INTEGER()),
-            Column('useBasePrice', Boolean(name='invgroup_usebaseprice')),
-            Column('anchored', Boolean(name='invgroup_anchored')),
-            Column('anchorable', Boolean(name='invgroup_anchorable')),
-            Column('fittableNonSingleton', Boolean(name='invgroup_fitnonsingle')),
-            Column('published', Boolean(name='invgroup_published')),
-            schema=schema
-
-
-    )
-
-
-    invItems =  Table('invItems', metadata,
-            Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(), nullable=False),
-            Column('ownerID', INTEGER(), nullable=False),
-            Column('locationID', INTEGER(), nullable=False,index=True),
-            Column('flagID', INTEGER(), nullable=False),
-            Column('quantity', INTEGER(), nullable=False),
-            schema=schema
-    )
-    Index('items_IX_OwnerLocation',invItems.c.ownerID,invItems.c.locationID)
-
-
-    invMarketGroups =  Table('invMarketGroups', metadata,
-            Column('marketGroupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('parentGroupID', INTEGER()),
-            Column('marketGroupName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=3000)),
-            Column('iconID', INTEGER()),
-            Column('hasTypes', Boolean(name='invmarketgroups_hastypes')),
-            schema=schema
-
-
-    )
-
-
-    invMetaGroups =  Table('invMetaGroups', metadata,
-            Column('metaGroupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('metaGroupName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('iconID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invMetaTypes =  Table('invMetaTypes', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('parentTypeID', INTEGER()),
-            Column('metaGroupID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invNames =  Table('invNames', metadata,
-            Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('itemName', VARCHAR(length=200), nullable=False),
-            schema=schema
-
-
-    )
-
-
-    invPositions =  Table('invPositions', metadata,
-            Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('x', FLOAT(), nullable=False, default=text("'0'")),
-            Column('y', FLOAT(), nullable=False, default=text("'0'")),
-            Column('z', FLOAT(), nullable=False, default=text("'0'")),
-            Column('yaw', FLOAT(precision=24)),
-            Column('pitch', FLOAT(precision=24)),
-            Column('roll', FLOAT(precision=24)),
-            schema=schema
-
-
-    )
-
-
-    invTraits =  Table('invTraits', metadata,
-            Column('traitID', INTEGER(), primary_key=True, autoincrement=True, nullable=False),
-            Column('typeID', INTEGER()),
-            Column('skillID', INTEGER()),
-            Column('bonus', FLOAT()),
-            Column('bonusText',UnicodeText()),
-            Column('unitID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invTypeMaterials =  Table('invTypeMaterials', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('materialTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('quantity', INTEGER(), nullable=False, default=text("'0'")),
-            schema=schema
-
-
-    )
-
-
-    invTypeReactions =  Table('invTypeReactions', metadata,
-            Column('reactionTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('input', Boolean(name='invtypereactions_input'), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('quantity', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invTypes =  Table('invTypes', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('groupID', INTEGER(),index=True),
-            Column('typeName', VARCHAR(length=100)),
-            Column('description',UnicodeText()),
-            Column('mass', FLOAT(precision=53)),
-            Column('volume', FLOAT(precision=53)),
-            Column('capacity', FLOAT(precision=53)),
-            Column('portionSize', INTEGER()),
-            Column('raceID', INTEGER()),
-            Column('basePrice', DECIMAL(precision=19, scale=4)),
-            Column('published', Boolean(name='invtype_published')),
-            Column('marketGroupID', INTEGER()),
-            Column('iconID', INTEGER()),
-            Column('soundID', INTEGER()),
-            Column('graphicID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    invUniqueNames =  Table('invUniqueNames', metadata,
-            Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('itemName', VARCHAR(length=200), nullable=False,index=True,unique=True),
-            Column('groupID', INTEGER()),
-            schema=schema
-    )
-    Index('invUniqueNames_IX_GroupName',invUniqueNames.c.groupID,invUniqueNames.c.itemName)
-
-
-    invVolumes =  Table('invVolumes', metadata,
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('volume', INTEGER()),
-            schema=schema
-    )
-
-
-    mapCelestialStatistics =  Table('mapCelestialStatistics', metadata,
-            Column('celestialID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('temperature', FLOAT(precision=53)),
-            Column('spectralClass', VARCHAR(length=10)),
-            Column('luminosity', FLOAT(precision=53)),
-            Column('age', FLOAT(precision=53)),
-            Column('life', FLOAT(precision=53)),
-            Column('orbitRadius', FLOAT(precision=53)),
-            Column('eccentricity', FLOAT(precision=53)),
-            Column('massDust', FLOAT(precision=53)),
-            Column('massGas', FLOAT(precision=53)),
-            Column('fragmented', Boolean(name='mapcelestialstats_frag')),
-            Column('density', FLOAT(precision=53)),
-            Column('surfaceGravity', FLOAT(precision=53)),
-            Column('escapeVelocity', FLOAT(precision=53)),
-            Column('orbitPeriod', FLOAT(precision=53)),
-            Column('rotationRate', FLOAT(precision=53)),
-            Column('locked', Boolean(name='mapcelestialstats_locked')),
-            Column('pressure', FLOAT(precision=53)),
-            Column('radius', FLOAT(precision=53)),
-            Column('mass', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapConstellationJumps =  Table('mapConstellationJumps', metadata,
-        Column('fromRegionID', INTEGER()),
-            Column('fromConstellationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('toConstellationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('toRegionID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapConstellations =  Table('mapConstellations', metadata,
-            Column('regionID', INTEGER()),
-            Column('constellationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('constellationName', VARCHAR(length=100)),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('xMin', FLOAT(precision=53)),
-            Column('xMax', FLOAT(precision=53)),
-            Column('yMin', FLOAT(precision=53)),
-            Column('yMax', FLOAT(precision=53)),
-            Column('zMin', FLOAT(precision=53)),
-            Column('zMax', FLOAT(precision=53)),
-            Column('factionID', INTEGER()),
-            Column('radius', FLOAT()),
-            schema=schema
-
-
-    )
-
-
-    mapDenormalize =  Table('mapDenormalize', metadata,
-            Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(),index=True),
-            Column('groupID', INTEGER()),
-            Column('solarSystemID', INTEGER(),index=True),
-            Column('constellationID', INTEGER(),index=True),
-            Column('regionID', INTEGER(),index=True),
-            Column('orbitID', INTEGER(),index=True),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('radius', FLOAT(precision=53)),
-            Column('itemName', VARCHAR(length=100)),
-            Column('security', FLOAT(precision=53)),
-            Column('celestialIndex', INTEGER()),
-            Column('orbitIndex', INTEGER()),
-            schema=schema
-    )
-    Index('mapDenormalize_IX_groupRegion',mapDenormalize.c.groupID,mapDenormalize.c.regionID)
-    Index('mapDenormalize_IX_groupSystem',mapDenormalize.c.groupID,mapDenormalize.c.solarSystemID)
-    Index('mapDenormalize_IX_groupConstellation',mapDenormalize.c.groupID,mapDenormalize.c.constellationID)
-
-
-
-
-    mapJumps =  Table('mapJumps', metadata,
-            Column('stargateID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('destinationID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapLandmarks =  Table('mapLandmarks', metadata,
-            Column('landmarkID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('landmarkName', VARCHAR(length=100)),
-            Column('description',UnicodeText()),
-            Column('locationID', INTEGER()),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('iconID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapLocationScenes =  Table('mapLocationScenes', metadata,
-            Column('locationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('graphicID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapLocationWormholeClasses =  Table('mapLocationWormholeClasses', metadata,
-            Column('locationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('wormholeClassID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapRegionJumps =  Table('mapRegionJumps', metadata,
-            Column('fromRegionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('toRegionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            schema=schema
-
-
-    )
-
-
-    mapRegions =  Table('mapRegions', metadata,
-            Column('regionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('regionName', VARCHAR(length=100)),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('xMin', FLOAT(precision=53)),
-            Column('xMax', FLOAT(precision=53)),
-            Column('yMin', FLOAT(precision=53)),
-            Column('yMax', FLOAT(precision=53)),
-            Column('zMin', FLOAT(precision=53)),
-            Column('zMax', FLOAT(precision=53)),
-            Column('factionID', INTEGER()),
-            Column('radius', FLOAT()),
-            schema=schema
-
-
-    )
-
-
-    mapSolarSystemJumps =  Table('mapSolarSystemJumps', metadata,
-            Column('fromRegionID', INTEGER()),
-            Column('fromConstellationID', INTEGER()),
-            Column('fromSolarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('toSolarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('toConstellationID', INTEGER()),
-            Column('toRegionID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    mapSolarSystems =  Table('mapSolarSystems', metadata,
-            Column('regionID', INTEGER(),index=True),
-            Column('constellationID', INTEGER(),index=True),
-            Column('solarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('solarSystemName', VARCHAR(length=100)),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('xMin', FLOAT(precision=53)),
-            Column('xMax', FLOAT(precision=53)),
-            Column('yMin', FLOAT(precision=53)),
-            Column('yMax', FLOAT(precision=53)),
-            Column('zMin', FLOAT(precision=53)),
-            Column('zMax', FLOAT(precision=53)),
-            Column('luminosity', FLOAT(precision=53)),
-            Column('border', Boolean(name='mapss_border')),
-            Column('fringe', Boolean(name='mapss_fringe')),
-            Column('corridor', Boolean(name='mapss_corridor')),
-            Column('hub', Boolean(name='mapss_hub')),
-            Column('international', Boolean(name='mapss_internat')),
-            Column('regional', Boolean(name='mapss_regional')),
-            Column('constellation', Boolean(name='mapss_constel')),
-            Column('security', FLOAT(precision=53),index=True),
-            Column('factionID', INTEGER()),
-            Column('radius', FLOAT(precision=53)),
-            Column('sunTypeID', INTEGER()),
-            Column('securityClass', VARCHAR(length=2)),
-            schema=schema
-    )
-
-
-    mapUniverse =  Table('mapUniverse', metadata,
-            Column('universeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('universeName', VARCHAR(length=100)),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('xMin', FLOAT(precision=53)),
-            Column('xMax', FLOAT(precision=53)),
-            Column('yMin', FLOAT(precision=53)),
-            Column('yMax', FLOAT(precision=53)),
-            Column('zMin', FLOAT(precision=53)),
-            Column('zMax', FLOAT(precision=53)),
-            Column('radius', FLOAT(precision=53)),
-            schema=schema
-    )
-
-
-    planetSchematics =  Table('planetSchematics', metadata,
-            Column('schematicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('schematicName', VARCHAR(length=255)),
-            Column('cycleTime', INTEGER()),
-            schema=schema
-    )
-
-
-    planetSchematicsPinMap =  Table('planetSchematicsPinMap', metadata,
-            Column('schematicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('pinTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            schema=schema
-    )
-
-
-    planetSchematicsTypeMap =  Table('planetSchematicsTypeMap', metadata,
-            Column('schematicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('quantity', INTEGER()),
-            Column('isInput', Boolean(name='pstm_input')),
-            schema=schema
-    )
-
-
-    ramActivities =  Table('ramActivities', metadata,
-            Column('activityID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('activityName', VARCHAR(length=100)),
-            Column('iconNo', VARCHAR(length=5)),
-            Column('description', VARCHAR(length=1000)),
-            Column('published', Boolean(name='ra_pub')),
-            schema=schema
-    )
-
-
-    ramAssemblyLineStations =  Table('ramAssemblyLineStations', metadata,
-            Column('stationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('quantity', INTEGER()),
-            Column('stationTypeID', INTEGER()),
-            Column('ownerID', INTEGER(),index=True),
-            Column('solarSystemID', INTEGER(),index=True),
-            Column('regionID', INTEGER(),index=True),
-            schema=schema
-
-
-    )
-
-
-    ramAssemblyLineTypeDetailPerCategory =  Table('ramAssemblyLineTypeDetailPerCategory', metadata,
-            Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('categoryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('timeMultiplier', FLOAT(precision=53)),
-            Column('materialMultiplier', FLOAT(precision=53)),
-            Column('costMultiplier', FLOAT(precision=53)),
-            schema=schema
-    )
-
-
-    ramAssemblyLineTypeDetailPerGroup =  Table('ramAssemblyLineTypeDetailPerGroup', metadata,
-            Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('groupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('timeMultiplier', FLOAT(precision=53)),
-            Column('materialMultiplier', FLOAT(precision=53)),
-            Column('costMultiplier', FLOAT(precision=53)),
-            schema=schema
-    )
-
-
-    ramAssemblyLineTypes =  Table('ramAssemblyLineTypes', metadata,
-            Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('assemblyLineTypeName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('baseTimeMultiplier', FLOAT(precision=53)),
-            Column('baseMaterialMultiplier', FLOAT(precision=53)),
-            Column('baseCostMultiplier', FLOAT(precision=53)),
-            Column('volume', FLOAT(precision=53)),
-            Column('activityID', INTEGER()),
-            Column('minCostPerHour', FLOAT(precision=53)),
-            schema=schema
-
-
-    )
-
-
-    ramInstallationTypeContents =  Table('ramInstallationTypeContents', metadata,
-            Column('installationTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('quantity', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    skinLicense =  Table('skinLicense', metadata,
-            Column('licenseTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('duration', INTEGER()),
-            Column('skinID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    skinMaterials =  Table('skinMaterials', metadata,
-            Column('skinMaterialID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('displayNameID', INTEGER()),
-            Column('materialSetID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    skinShip =  Table('skinShip', metadata,
-            Column('skinID', INTEGER(),index=True),
-            Column('typeID', INTEGER(),index=True),
-            schema=schema
-
-
-    )
-
-
-    skins =  Table('skins', metadata,
-            Column('skinID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('internalName', VARCHAR(length=70)),
-            Column('skinMaterialID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    staOperationServices =  Table('staOperationServices', metadata,
-            Column('operationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('serviceID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            schema=schema
-
-
-    )
-
-
-    staOperations =  Table('staOperations', metadata,
-            Column('activityID', INTEGER()),
-            Column('operationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('operationName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            Column('fringe', INTEGER()),
-            Column('corridor', INTEGER()),
-            Column('hub', INTEGER()),
-            Column('border', INTEGER()),
-            Column('ratio', INTEGER()),
-            Column('caldariStationTypeID', INTEGER()),
-            Column('minmatarStationTypeID', INTEGER()),
-            Column('amarrStationTypeID', INTEGER()),
-            Column('gallenteStationTypeID', INTEGER()),
-            Column('joveStationTypeID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    staServices =  Table('staServices', metadata,
-            Column('serviceID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('serviceName', VARCHAR(length=100)),
-            Column('description', VARCHAR(length=1000)),
-            schema=schema
-
-
-    )
-
-
-    staStationTypes =  Table('staStationTypes', metadata,
-            Column('stationTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('dockEntryX', FLOAT(precision=53)),
-            Column('dockEntryY', FLOAT(precision=53)),
-            Column('dockEntryZ', FLOAT(precision=53)),
-            Column('dockOrientationX', FLOAT(precision=53)),
-            Column('dockOrientationY', FLOAT(precision=53)),
-            Column('dockOrientationZ', FLOAT(precision=53)),
-            Column('operationID', INTEGER()),
-            Column('officeSlots', INTEGER()),
-            Column('reprocessingEfficiency', FLOAT(precision=53)),
-            Column('conquerable', Boolean(name='stastat_conq')),
-            schema=schema
-
-
-    )
-
-
-    staStations =  Table('staStations', metadata,
-            Column('stationID', BigInteger, primary_key=True, autoincrement=False, nullable=False),
-            Column('security', FLOAT(precision=53)),
-            Column('dockingCostPerVolume', FLOAT(precision=53)),
-            Column('maxShipVolumeDockable', FLOAT(precision=53)),
-            Column('officeRentalCost', INTEGER()),
-            Column('operationID', INTEGER(),index=True),
-            Column('stationTypeID', INTEGER(),index=True),
-            Column('corporationID', INTEGER(),index=True),
-            Column('solarSystemID', INTEGER(),index=True),
-            Column('constellationID', INTEGER(),index=True),
-            Column('regionID', INTEGER(),index=True),
-            Column('stationName', VARCHAR(length=100)),
-            Column('x', FLOAT(precision=53)),
-            Column('y', FLOAT(precision=53)),
-            Column('z', FLOAT(precision=53)),
-            Column('reprocessingEfficiency', FLOAT(precision=53)),
-            Column('reprocessingStationsTake', FLOAT(precision=53)),
-            Column('reprocessingHangarFlag', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    translationTables =  Table('translationTables', metadata,
-            Column('sourceTable', VARCHAR(length=200), primary_key=True, autoincrement=False, nullable=False),
-            Column('destinationTable', VARCHAR(length=200)),
-            Column('translatedKey', VARCHAR(length=200), primary_key=True, autoincrement=False, nullable=False),
-            Column('tcGroupID', INTEGER()),
-            Column('tcID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    trnTranslationColumns =  Table('trnTranslationColumns', metadata,
-            Column('tcGroupID', INTEGER()),
-            Column('tcID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('tableName', VARCHAR(length=256), nullable=False),
-            Column('columnName', VARCHAR(length=128), nullable=False),
-            Column('masterID', VARCHAR(length=128)),
-            schema=schema
-
-
-    )
-
-
-    trnTranslationLanguages =  Table('trnTranslationLanguages', metadata,
-            Column('numericLanguageID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('languageID', VARCHAR(length=50)),
-            Column('languageName', VARCHAR(length=200)),
-            schema=schema
-
-
-    )
-
-
-    trnTranslations =  Table('trnTranslations', metadata,
-            Column('tcID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('keyID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('languageID', VARCHAR(length=50), primary_key=True, autoincrement=False, nullable=False),
-            Column('text',UnicodeText(), nullable=False),
-            schema=schema
-
-
-    )
-
-
-    warCombatZoneSystems =  Table('warCombatZoneSystems', metadata,
-            Column('solarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('combatZoneID', INTEGER()),
-            schema=schema
-
-
-    )
-
-
-    warCombatZones =  Table('warCombatZones', metadata,
-            Column('combatZoneID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('combatZoneName', VARCHAR(length=100)),
-            Column('factionID', INTEGER()),
-            Column('centerSystemID', INTEGER()),
-            Column('description', VARCHAR(length=500)),
-            schema=schema
-
-
-    )
+	metadata = MetaData(schema=schema)
+
+
+	agtAgentTypes =  Table('agtAgentTypes', metadata,
+		Column('agentTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('agentType', VARCHAR(length=50))
+	)
+
+
+	agtAgents =  Table('agtAgents', metadata,
+		Column('agentID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('divisionID', INTEGER()),
+		Column('corporationID', INTEGER(),index=True),
+		Column('locationID', INTEGER(),index=True),
+		Column('level', INTEGER()),
+		Column('quality', INTEGER()),
+		Column('agentTypeID', INTEGER()),
+		Column('isLocator', Boolean(name='aa_isloc')),
+		schema=schema
+	)
+
+
+	agtResearchAgents =  Table('agtResearchAgents', metadata,
+		Column('agentID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
+		schema=schema
+	)
+
+
+	certCerts =  Table('certCerts', metadata,
+		Column('certID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('description',UnicodeText()),
+		Column('groupID', INTEGER()),
+		Column('name', VARCHAR(length=255)),
+		schema=schema
+	)
+
+
+	certMasteries =  Table('certMasteries', metadata,
+		Column('typeID', INTEGER()),
+		Column('masteryLevel', INTEGER()),
+		Column('certID', INTEGER()),
+		schema=schema
+	)
+
+
+	certSkills =  Table('certSkills', metadata,
+		Column('certID', INTEGER()),
+		Column('skillID', INTEGER(),index=True),
+		Column('certLevelInt', INTEGER()),
+		Column('skillLevel', INTEGER()),
+		Column('certLevelText', VARCHAR(length=8)),
+		schema=schema
+	)
+
+
+	chrAncestries =  Table('chrAncestries', metadata,
+		Column('ancestryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('ancestryName', VARCHAR(length=100)),
+		Column('bloodlineID', INTEGER()),
+		Column('description', VARCHAR(length=1000)),
+		Column('perception', INTEGER()),
+		Column('willpower', INTEGER()),
+		Column('charisma', INTEGER()),
+		Column('memory', INTEGER()),
+		Column('intelligence', INTEGER()),
+		Column('iconID', INTEGER()),
+		Column('shortDescription', VARCHAR(length=500)),
+		schema=schema
+	)
+
+
+	chrAttributes =  Table('chrAttributes', metadata,
+		Column('attributeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('attributeName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('iconID', INTEGER()),
+		Column('shortDescription', VARCHAR(length=500)),
+		Column('notes', VARCHAR(length=500)),
+		schema=schema
+	)
+
+
+	chrBloodlines =  Table('chrBloodlines', metadata,
+		Column('bloodlineID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('bloodlineName', VARCHAR(length=100)),
+		Column('raceID', INTEGER()),
+		Column('description', VARCHAR(length=1000)),
+		Column('maleDescription', VARCHAR(length=1000)),
+		Column('femaleDescription', VARCHAR(length=1000)),
+		Column('shipTypeID', INTEGER()),
+		Column('corporationID', INTEGER()),
+		Column('perception', INTEGER()),
+		Column('willpower', INTEGER()),
+		Column('charisma', INTEGER()),
+		Column('memory', INTEGER()),
+		Column('intelligence', INTEGER()),
+		Column('iconID', INTEGER()),
+		Column('shortDescription', VARCHAR(length=500)),
+		Column('shortMaleDescription', VARCHAR(length=500)),
+		Column('shortFemaleDescription', VARCHAR(length=500)),
+		schema=schema
+	)
+
+
+	chrFactions =  Table('chrFactions', metadata,
+		Column('factionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('factionName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('raceIDs', INTEGER()),
+		Column('solarSystemID', INTEGER()),
+		Column('corporationID', INTEGER()),
+		Column('sizeFactor', FLOAT()),
+		Column('stationCount', INTEGER()),
+		Column('stationSystemCount', INTEGER()),
+		Column('militiaCorporationID', INTEGER()),
+		Column('iconID', INTEGER()),
+		schema=schema
+	)
+
+
+	chrRaces =  Table('chrRaces', metadata,
+		Column('raceID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('raceName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('iconID', INTEGER()),
+		Column('shortDescription', VARCHAR(length=500)),
+		schema=schema
+	)
+
+
+	crpActivities =  Table('crpActivities', metadata,
+		Column('activityID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('activityName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		schema=schema
+	)
+
+
+	crpNPCCorporationDivisions =  Table('crpNPCCorporationDivisions', metadata,
+		Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('divisionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('size', INTEGER()),
+		schema=schema
+	)
+
+
+	crpNPCCorporationResearchFields =  Table('crpNPCCorporationResearchFields', metadata,
+		Column('skillID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		schema=schema
+	)
+
+
+	crpNPCCorporationTrades =  Table('crpNPCCorporationTrades', metadata,
+		Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		schema=schema
+	)
+
+
+	crpNPCCorporations =  Table('crpNPCCorporations', metadata,
+		Column('corporationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('size', CHAR(length=1)),
+		Column('extent', CHAR(length=1)),
+		Column('solarSystemID', INTEGER()),
+		Column('investorID1', INTEGER()),
+		Column('investorShares1', INTEGER()),
+		Column('investorID2', INTEGER()),
+		Column('investorShares2', INTEGER()),
+		Column('investorID3', INTEGER()),
+		Column('investorShares3', INTEGER()),
+		Column('investorID4', INTEGER()),
+		Column('investorShares4', INTEGER()),
+		Column('friendID', INTEGER()),
+		Column('enemyID', INTEGER()),
+		Column('publicShares', INTEGER()),
+		Column('initialPrice', INTEGER()),
+		Column('minSecurity', FLOAT()),
+		Column('scattered', Boolean(name='cnpcc_scatt')),
+		Column('fringe', INTEGER()),
+		Column('corridor', INTEGER()),
+		Column('hub', INTEGER()),
+		Column('border', INTEGER()),
+		Column('factionID', INTEGER()),
+		Column('sizeFactor', FLOAT()),
+		Column('stationCount', INTEGER()),
+		Column('stationSystemCount', INTEGER()),
+		Column('description', VARCHAR(length=4000)),
+		Column('iconID', INTEGER()),
+		schema=schema
+	)
+
+
+	crpNPCDivisions =  Table('crpNPCDivisions', metadata,
+		Column('divisionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('divisionName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('leaderType', VARCHAR(length=100)),
+		schema=schema
+	)
+
+
+	dgmAttributeCategories =  Table('dgmAttributeCategories', metadata,
+		Column('categoryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('categoryName', VARCHAR(length=50)),
+		Column('categoryDescription', VARCHAR(length=200)),
+		schema=schema
+	)
+
+
+	dgmAttributeTypes =  Table('dgmAttributeTypes', metadata,
+		Column('attributeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('attributeName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('iconID', INTEGER()),
+		Column('defaultValue', FLOAT()),
+		Column('published', Boolean(name='dat_pub')),
+		Column('displayName', VARCHAR(length=150)),
+		Column('unitID', INTEGER()),
+		Column('stackable', Boolean(name='dat_stack')),
+		Column('highIsGood', Boolean(name='dat_hig')),
+		Column('categoryID', INTEGER()),
+		schema=schema
+	)
+
+
+	dgmEffects =  Table('dgmEffects', metadata,
+		Column('effectID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('effectName', VARCHAR(length=400)),
+		Column('effectCategory', INTEGER()),
+		Column('preExpression', INTEGER()),
+		Column('postExpression', INTEGER()),
+		Column('description', VARCHAR(length=1000)),
+		Column('guid', VARCHAR(length=60)),
+		Column('iconID', INTEGER()),
+		Column('isOffensive', Boolean(name='de_offense')),
+		Column('isAssistance', Boolean(name='de_assist')),
+		Column('durationAttributeID', INTEGER()),
+		Column('trackingSpeedAttributeID', INTEGER()),
+		Column('dischargeAttributeID', INTEGER()),
+		Column('rangeAttributeID', INTEGER()),
+		Column('falloffAttributeID', INTEGER()),
+		Column('disallowAutoRepeat', Boolean(name='de_disallowar')),
+		Column('published', Boolean(name='de_published')),
+		Column('displayName', VARCHAR(length=100)),
+		Column('isWarpSafe', Boolean(name='de_warpsafe')),
+		Column('rangeChance', Boolean(name='de_rangechance')),
+		Column('electronicChance', Boolean(name='de_elecchance')),
+		Column('propulsionChance', Boolean(name='de_propchance')),
+		Column('distribution', INTEGER()),
+		Column('sfxName', VARCHAR(length=20)),
+		Column('npcUsageChanceAttributeID', INTEGER()),
+		Column('npcActivationChanceAttributeID', INTEGER()),
+		Column('fittingUsageChanceAttributeID', INTEGER()),
+		Column('modifierInfo',UnicodeText()),
+		schema=schema
+	)
+
+
+	dgmExpressions =  Table('dgmExpressions', metadata,
+		Column('expressionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('operandID', INTEGER()),
+		Column('arg1', INTEGER()),
+		Column('arg2', INTEGER()),
+		Column('expressionValue', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('expressionName', VARCHAR(length=500)),
+		Column('expressionTypeID', INTEGER()),
+		Column('expressionGroupID', INTEGER()),
+		Column('expressionAttributeID', INTEGER()),
+		schema=schema
+	)
+
+
+	dgmTypeAttributes =  Table('dgmTypeAttributes', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('attributeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
+		Column('valueInt', INTEGER()),
+		Column('valueFloat', FLOAT()),
+		schema=schema
+	)
+
+
+	dgmTypeEffects =  Table('dgmTypeEffects', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('effectID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('isDefault', Boolean(name='dte_default')),
+		schema=schema
+    )
+
+
+	eveGraphics =  Table('eveGraphics', metadata,
+		Column('graphicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('sofFactionName', VARCHAR(length=100)),
+		Column('graphicFile', VARCHAR(length=100)),
+		Column('sofHullName', VARCHAR(length=100)),
+		Column('sofRaceName', VARCHAR(length=100)),
+		Column('description',UnicodeText()),
+		schema=schema
+	)
+
+
+	eveIcons =  Table('eveIcons', metadata,
+		Column('iconID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('iconFile', VARCHAR(length=500)),
+		Column('description',UnicodeText()),
+		schema=schema
+	)
+
+
+	eveUnits =  Table('eveUnits', metadata,
+		Column('unitID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('unitName', VARCHAR(length=100)),
+		Column('displayName', VARCHAR(length=50)),
+		Column('description', VARCHAR(length=1000)),
+		schema=schema
+	)
+
+
+	industryActivity =  Table('industryActivity', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('activityID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
+		Column('time', INTEGER()),
+		schema=schema
+	)
+
+
+	industryActivityMaterials =  Table('industryActivityMaterials', metadata,
+		Column('typeID', INTEGER(),index=True),
+		Column('activityID', INTEGER()),
+		Column('materialTypeID', INTEGER()),
+		Column('quantity', INTEGER()),
+		schema=schema
+	)
+	Index('industryActivityMaterials_idx1',industryActivityMaterials.c.typeID,industryActivityMaterials.c.activityID)
+
+
+	industryActivityProbabilities =  Table('industryActivityProbabilities', metadata,
+		Column('typeID', INTEGER(),index=True),
+		Column('activityID', INTEGER()),
+		Column('productTypeID', INTEGER(),index=True),
+		Column('probability', DECIMAL(precision=3, scale=2)),
+		schema=schema
+	)
+
+
+	industryActivityProducts =  Table('industryActivityProducts', metadata,
+		Column('typeID', INTEGER(),index=True),
+		Column('activityID', INTEGER()),
+		Column('productTypeID', INTEGER(),index=True),
+		Column('quantity', INTEGER()),
+		schema=schema
+	)
+
+
+	industryActivityRaces =  Table('industryActivityRaces', metadata,
+		Column('typeID', INTEGER(),index=True),
+		Column('activityID', INTEGER()),
+		Column('productTypeID', INTEGER(),index=True),
+		Column('raceID', INTEGER()),
+		schema=schema
+	)
+
+
+	industryActivitySkills =  Table('industryActivitySkills', metadata,
+		Column('typeID', INTEGER(),index=True),
+		Column('activityID', INTEGER()),
+		Column('skillID', INTEGER(),index=True),
+		Column('level', INTEGER()),
+		schema=schema
+	)
+	Index('industryActivitySkills_idx1',industryActivitySkills.c.typeID,industryActivitySkills.c.activityID)
+
+	industryBlueprints =  Table('industryBlueprints', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('maxProductionLimit', INTEGER()),
+		schema=schema
+	)
+
+
+	invCategories =  Table('invCategories', metadata,
+		Column('categoryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('categoryName', VARCHAR(length=100)),
+		Column('iconID', INTEGER()),
+		Column('published', Boolean(name='invcat_published')),
+		schema=schema
+	)
+
+
+	invContrabandTypes =  Table('invContrabandTypes', metadata,
+		Column('factionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False,index=True),
+		Column('standingLoss', FLOAT(precision=53)),
+		Column('confiscateMinSec', FLOAT(precision=53)),
+		Column('fineByValue', FLOAT(precision=53)),
+		Column('attackMinSec', FLOAT(precision=53)),
+		schema=schema
+	)
+
+
+	invControlTowerResourcePurposes =  Table('invControlTowerResourcePurposes', metadata,
+		Column('purpose', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('purposeText', VARCHAR(length=100)),
+		schema=schema
+	)
+
+
+	invControlTowerResources =  Table('invControlTowerResources', metadata,
+		Column('controlTowerTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('resourceTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('purpose', INTEGER()),
+		Column('quantity', INTEGER()),
+		Column('minSecurityLevel', FLOAT(precision=53)),
+		Column('factionID', INTEGER()),
+		schema=schema
+	)
+
+
+	invFlags =  Table('invFlags', metadata,
+		Column('flagID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('flagName', VARCHAR(length=200)),
+		Column('flagText', VARCHAR(length=100)),
+		Column('orderID', INTEGER()),
+		schema=schema
+	)
+
+
+	invGroups =  Table('invGroups', metadata,
+		Column('groupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('categoryID', INTEGER(),index=True),
+		Column('groupName', VARCHAR(length=100)),
+		Column('iconID', INTEGER()),
+		Column('useBasePrice', Boolean(name='invgroup_usebaseprice')),
+		Column('anchored', Boolean(name='invgroup_anchored')),
+		Column('anchorable', Boolean(name='invgroup_anchorable')),
+		Column('fittableNonSingleton', Boolean(name='invgroup_fitnonsingle')),
+		Column('published', Boolean(name='invgroup_published')),
+		schema=schema
+	)
+
+
+	invItems =  Table('invItems', metadata,
+		Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(), nullable=False),
+		Column('ownerID', INTEGER(), nullable=False),
+		Column('locationID', INTEGER(), nullable=False,index=True),
+		Column('flagID', INTEGER(), nullable=False),
+		Column('quantity', INTEGER(), nullable=False),
+		schema=schema
+	)
+	Index('items_IX_OwnerLocation',invItems.c.ownerID,invItems.c.locationID)
+
+
+	invMarketGroups =  Table('invMarketGroups', metadata,
+		Column('marketGroupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('parentGroupID', INTEGER()),
+		Column('marketGroupName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=3000)),
+		Column('iconID', INTEGER()),
+		Column('hasTypes', Boolean(name='invmarketgroups_hastypes')),
+		schema=schema
+	)
+
+
+	invMetaGroups =  Table('invMetaGroups', metadata,
+		Column('metaGroupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('metaGroupName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('iconID', INTEGER()),
+		schema=schema
+	)
+
+
+	invMetaTypes =  Table('invMetaTypes', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('parentTypeID', INTEGER()),
+		Column('metaGroupID', INTEGER()),
+		schema=schema
+	)
+
+
+	invNames =  Table('invNames', metadata,
+		Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('itemName', VARCHAR(length=200), nullable=False),
+		schema=schema
+	)
+
+
+	invPositions =  Table('invPositions', metadata,
+		Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('x', FLOAT(), nullable=False, default=text("'0'")),
+		Column('y', FLOAT(), nullable=False, default=text("'0'")),
+		Column('z', FLOAT(), nullable=False, default=text("'0'")),
+		Column('yaw', FLOAT(precision=24)),
+		Column('pitch', FLOAT(precision=24)),
+		Column('roll', FLOAT(precision=24)),
+		schema=schema
+	)
+
+
+	invTraits =  Table('invTraits', metadata,
+		Column('traitID', INTEGER(), primary_key=True, autoincrement=True, nullable=False),
+		Column('typeID', INTEGER()),
+		Column('skillID', INTEGER()),
+		Column('bonus', FLOAT()),
+		Column('bonusText',UnicodeText()),
+		Column('unitID', INTEGER()),
+		schema=schema
+	)
+
+
+	invTypeMaterials =  Table('invTypeMaterials', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('materialTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('quantity', INTEGER(), nullable=False, default=text("'0'")),
+		schema=schema
+	)
+
+
+	invTypeReactions =  Table('invTypeReactions', metadata,
+		Column('reactionTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('input', Boolean(name='invtypereactions_input'), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('quantity', INTEGER()),
+		schema=schema
+	)
+
+
+	invTypes =  Table('invTypes', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('groupID', INTEGER(),index=True),
+		Column('typeName', VARCHAR(length=100)),
+		Column('description',UnicodeText()),
+		Column('mass', FLOAT(precision=53)),
+		Column('volume', FLOAT(precision=53)),
+		Column('capacity', FLOAT(precision=53)),
+		Column('portionSize', INTEGER()),
+		Column('raceID', INTEGER()),
+		Column('basePrice', DECIMAL(precision=19, scale=4)),
+		Column('published', Boolean(name='invtype_published')),
+		Column('marketGroupID', INTEGER()),
+		Column('iconID', INTEGER()),
+		Column('soundID', INTEGER()),
+		Column('graphicID', INTEGER()),
+		schema=schema
+	)
+
+
+	invUniqueNames =  Table('invUniqueNames', metadata,
+		Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('itemName', VARCHAR(length=200), nullable=False,index=True,unique=True),
+		Column('groupID', INTEGER()),
+		schema=schema
+	)
+	Index('invUniqueNames_IX_GroupName',invUniqueNames.c.groupID,invUniqueNames.c.itemName)
+
+
+	invVolumes =  Table('invVolumes', metadata,
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('volume', INTEGER()),
+		schema=schema
+	)
+
+
+	mapCelestialStatistics =  Table('mapCelestialStatistics', metadata,
+		Column('celestialID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('temperature', FLOAT(precision=53)),
+		Column('spectralClass', VARCHAR(length=10)),
+		Column('luminosity', FLOAT(precision=53)),
+		Column('age', FLOAT(precision=53)),
+		Column('life', FLOAT(precision=53)),
+		Column('orbitRadius', FLOAT(precision=53)),
+		Column('eccentricity', FLOAT(precision=53)),
+		Column('massDust', FLOAT(precision=53)),
+		Column('massGas', FLOAT(precision=53)),
+		Column('fragmented', Boolean(name='mapcelestialstats_frag')),
+		Column('density', FLOAT(precision=53)),
+		Column('surfaceGravity', FLOAT(precision=53)),
+		Column('escapeVelocity', FLOAT(precision=53)),
+		Column('orbitPeriod', FLOAT(precision=53)),
+		Column('rotationRate', FLOAT(precision=53)),
+		Column('locked', Boolean(name='mapcelestialstats_locked')),
+		Column('pressure', FLOAT(precision=53)),
+		Column('radius', FLOAT(precision=53)),
+		Column('mass', INTEGER()),
+		schema=schema
+	)
+
+
+	mapConstellationJumps =  Table('mapConstellationJumps', metadata,
+		Column('fromRegionID', INTEGER()),
+		Column('fromConstellationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('toConstellationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('toRegionID', INTEGER()),
+		schema=schema
+	)
+
+
+	mapConstellations =  Table('mapConstellations', metadata,
+		Column('regionID', INTEGER()),
+		Column('constellationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('constellationName', VARCHAR(length=100)),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('xMin', FLOAT(precision=53)),
+		Column('xMax', FLOAT(precision=53)),
+		Column('yMin', FLOAT(precision=53)),
+		Column('yMax', FLOAT(precision=53)),
+		Column('zMin', FLOAT(precision=53)),
+		Column('zMax', FLOAT(precision=53)),
+		Column('factionID', INTEGER()),
+		Column('radius', FLOAT()),
+		schema=schema
+	)
+
+
+	mapDenormalize =  Table('mapDenormalize', metadata,
+		Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(),index=True),
+		Column('groupID', INTEGER()),
+		Column('solarSystemID', INTEGER(),index=True),
+		Column('constellationID', INTEGER(),index=True),
+		Column('regionID', INTEGER(),index=True),
+		Column('orbitID', INTEGER(),index=True),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('radius', FLOAT(precision=53)),
+		Column('itemName', VARCHAR(length=100)),
+		Column('security', FLOAT(precision=53)),
+		Column('celestialIndex', INTEGER()),
+		Column('orbitIndex', INTEGER()),
+		schema=schema
+	)
+	Index('mapDenormalize_IX_groupRegion',mapDenormalize.c.groupID,mapDenormalize.c.regionID)
+	Index('mapDenormalize_IX_groupSystem',mapDenormalize.c.groupID,mapDenormalize.c.solarSystemID)
+	Index('mapDenormalize_IX_groupConstellation',mapDenormalize.c.groupID,mapDenormalize.c.constellationID)
+
+
+
+
+	mapJumps =  Table('mapJumps', metadata,
+		Column('stargateID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('destinationID', INTEGER()),
+		schema=schema
+	)
+
+
+	mapLandmarks =  Table('mapLandmarks', metadata,
+		Column('landmarkID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('landmarkName', VARCHAR(length=100)),
+		Column('description',UnicodeText()),
+		Column('locationID', INTEGER()),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('iconID', INTEGER()),
+		schema=schema
+	)
+
+
+	mapLocationScenes =  Table('mapLocationScenes', metadata,
+		Column('locationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('graphicID', INTEGER()),
+		schema=schema
+	)
+
+
+	mapLocationWormholeClasses =  Table('mapLocationWormholeClasses', metadata,
+		Column('locationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('wormholeClassID', INTEGER()),
+		schema=schema
+	)
+
+
+	mapRegionJumps =  Table('mapRegionJumps', metadata,
+		Column('fromRegionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('toRegionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		schema=schema
+	)
+
+
+	mapRegions =  Table('mapRegions', metadata,
+		Column('regionID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('regionName', VARCHAR(length=100)),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('xMin', FLOAT(precision=53)),
+		Column('xMax', FLOAT(precision=53)),
+		Column('yMin', FLOAT(precision=53)),
+		Column('yMax', FLOAT(precision=53)),
+		Column('zMin', FLOAT(precision=53)),
+		Column('zMax', FLOAT(precision=53)),
+		Column('factionID', INTEGER()),
+		Column('radius', FLOAT()),
+		schema=schema
+	)
+
+
+	mapSolarSystemJumps =  Table('mapSolarSystemJumps', metadata,
+		Column('fromRegionID', INTEGER()),
+		Column('fromConstellationID', INTEGER()),
+		Column('fromSolarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('toSolarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('toConstellationID', INTEGER()),
+		Column('toRegionID', INTEGER()),
+		schema=schema
+	)
+
+
+	mapSolarSystems =  Table('mapSolarSystems', metadata,
+		Column('regionID', INTEGER(),index=True),
+		Column('constellationID', INTEGER(),index=True),
+		Column('solarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('solarSystemName', VARCHAR(length=100)),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('xMin', FLOAT(precision=53)),
+		Column('xMax', FLOAT(precision=53)),
+		Column('yMin', FLOAT(precision=53)),
+		Column('yMax', FLOAT(precision=53)),
+		Column('zMin', FLOAT(precision=53)),
+		Column('zMax', FLOAT(precision=53)),
+		Column('luminosity', FLOAT(precision=53)),
+		Column('border', Boolean(name='mapss_border')),
+		Column('fringe', Boolean(name='mapss_fringe')),
+		Column('corridor', Boolean(name='mapss_corridor')),
+		Column('hub', Boolean(name='mapss_hub')),
+		Column('international', Boolean(name='mapss_internat')),
+		Column('regional', Boolean(name='mapss_regional')),
+		Column('constellation', Boolean(name='mapss_constel')),
+		Column('security', FLOAT(precision=53),index=True),
+		Column('factionID', INTEGER()),
+		Column('radius', FLOAT(precision=53)),
+		Column('sunTypeID', INTEGER()),
+		Column('securityClass', VARCHAR(length=2)),
+		schema=schema
+	)
+
+
+	mapUniverse =  Table('mapUniverse', metadata,
+		Column('universeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('universeName', VARCHAR(length=100)),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('xMin', FLOAT(precision=53)),
+		Column('xMax', FLOAT(precision=53)),
+		Column('yMin', FLOAT(precision=53)),
+		Column('yMax', FLOAT(precision=53)),
+		Column('zMin', FLOAT(precision=53)),
+		Column('zMax', FLOAT(precision=53)),
+		Column('radius', FLOAT(precision=53)),
+		schema=schema
+	)
+
+
+	planetSchematics =  Table('planetSchematics', metadata,
+		Column('schematicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('schematicName', VARCHAR(length=255)),
+		Column('cycleTime', INTEGER()),
+		schema=schema
+	)
+
+
+	planetSchematicsPinMap =  Table('planetSchematicsPinMap', metadata,
+		Column('schematicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('pinTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		schema=schema
+	)
+
+
+	planetSchematicsTypeMap =  Table('planetSchematicsTypeMap', metadata,
+		Column('schematicID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('quantity', INTEGER()),
+		Column('isInput', Boolean(name='pstm_input')),
+		schema=schema
+	)
+
+
+	ramActivities =  Table('ramActivities', metadata,
+		Column('activityID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('activityName', VARCHAR(length=100)),
+		Column('iconNo', VARCHAR(length=5)),
+		Column('description', VARCHAR(length=1000)),
+		Column('published', Boolean(name='ra_pub')),
+		schema=schema
+	)
+
+
+	ramAssemblyLineStations =  Table('ramAssemblyLineStations', metadata,
+		Column('stationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('quantity', INTEGER()),
+		Column('stationTypeID', INTEGER()),
+		Column('ownerID', INTEGER(),index=True),
+		Column('solarSystemID', INTEGER(),index=True),
+		Column('regionID', INTEGER(),index=True),
+		schema=schema
+	)
+
+
+	ramAssemblyLineTypeDetailPerCategory =  Table('ramAssemblyLineTypeDetailPerCategory', metadata,
+		Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('categoryID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('timeMultiplier', FLOAT(precision=53)),
+		Column('materialMultiplier', FLOAT(precision=53)),
+		Column('costMultiplier', FLOAT(precision=53)),
+		schema=schema
+	)
+
+
+	ramAssemblyLineTypeDetailPerGroup =  Table('ramAssemblyLineTypeDetailPerGroup', metadata,
+		Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('groupID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('timeMultiplier', FLOAT(precision=53)),
+		Column('materialMultiplier', FLOAT(precision=53)),
+		Column('costMultiplier', FLOAT(precision=53)),
+		schema=schema
+	)
+
+
+	ramAssemblyLineTypes =  Table('ramAssemblyLineTypes', metadata,
+		Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('assemblyLineTypeName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('baseTimeMultiplier', FLOAT(precision=53)),
+		Column('baseMaterialMultiplier', FLOAT(precision=53)),
+		Column('baseCostMultiplier', FLOAT(precision=53)),
+		Column('volume', FLOAT(precision=53)),
+		Column('activityID', INTEGER()),
+		Column('minCostPerHour', FLOAT(precision=53)),
+		schema=schema
+	)
+
+
+	ramInstallationTypeContents =  Table('ramInstallationTypeContents', metadata,
+		Column('installationTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('assemblyLineTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('quantity', INTEGER()),
+		schema=schema
+	)
+
+
+	skinLicense =  Table('skinLicense', metadata,
+		Column('licenseTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('duration', INTEGER()),
+		Column('skinID', INTEGER()),
+		schema=schema
+	)
+
+
+	skinMaterials =  Table('skinMaterials', metadata,
+		Column('skinMaterialID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('displayNameID', INTEGER()),
+		Column('materialSetID', INTEGER()),
+		schema=schema
+	)
+
+
+	skinShip =  Table('skinShip', metadata,
+		Column('skinID', INTEGER(),index=True),
+		Column('typeID', INTEGER(),index=True),
+		schema=schema
+	)
+
+
+	skins =  Table('skins', metadata,
+		Column('skinID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('internalName', VARCHAR(length=70)),
+		Column('skinMaterialID', INTEGER()),
+		schema=schema
+	)
+
+
+	staOperationServices =  Table('staOperationServices', metadata,
+		Column('operationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('serviceID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		schema=schema
+	)
+
+
+	staOperations =  Table('staOperations', metadata,
+		Column('activityID', INTEGER()),
+		Column('operationID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('operationName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		Column('fringe', INTEGER()),
+		Column('corridor', INTEGER()),
+		Column('hub', INTEGER()),
+		Column('border', INTEGER()),
+		Column('ratio', INTEGER()),
+		Column('caldariStationTypeID', INTEGER()),
+		Column('minmatarStationTypeID', INTEGER()),
+		Column('amarrStationTypeID', INTEGER()),
+		Column('gallenteStationTypeID', INTEGER()),
+		Column('joveStationTypeID', INTEGER()),
+		schema=schema
+	)
+
+
+	staServices =  Table('staServices', metadata,
+		Column('serviceID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('serviceName', VARCHAR(length=100)),
+		Column('description', VARCHAR(length=1000)),
+		schema=schema
+	)
+
+
+	staStationTypes =  Table('staStationTypes', metadata,
+		Column('stationTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('dockEntryX', FLOAT(precision=53)),
+		Column('dockEntryY', FLOAT(precision=53)),
+		Column('dockEntryZ', FLOAT(precision=53)),
+		Column('dockOrientationX', FLOAT(precision=53)),
+		Column('dockOrientationY', FLOAT(precision=53)),
+		Column('dockOrientationZ', FLOAT(precision=53)),
+		Column('operationID', INTEGER()),
+		Column('officeSlots', INTEGER()),
+		Column('reprocessingEfficiency', FLOAT(precision=53)),
+		Column('conquerable', Boolean(name='stastat_conq')),
+		schema=schema
+	)
+
+
+	staStations =  Table('staStations', metadata,
+		Column('stationID', BigInteger, primary_key=True, autoincrement=False, nullable=False),
+		Column('security', FLOAT(precision=53)),
+		Column('dockingCostPerVolume', FLOAT(precision=53)),
+		Column('maxShipVolumeDockable', FLOAT(precision=53)),
+		Column('officeRentalCost', INTEGER()),
+		Column('operationID', INTEGER(),index=True),
+		Column('stationTypeID', INTEGER(),index=True),
+		Column('corporationID', INTEGER(),index=True),
+		Column('solarSystemID', INTEGER(),index=True),
+		Column('constellationID', INTEGER(),index=True),
+		Column('regionID', INTEGER(),index=True),
+		Column('stationName', VARCHAR(length=100)),
+		Column('x', FLOAT(precision=53)),
+		Column('y', FLOAT(precision=53)),
+		Column('z', FLOAT(precision=53)),
+		Column('reprocessingEfficiency', FLOAT(precision=53)),
+		Column('reprocessingStationsTake', FLOAT(precision=53)),
+		Column('reprocessingHangarFlag', INTEGER()),
+		schema=schema
+	)
+
+
+	translationTables =  Table('translationTables', metadata,
+		Column('sourceTable', VARCHAR(length=200), primary_key=True, autoincrement=False, nullable=False),
+		Column('destinationTable', VARCHAR(length=200)),
+		Column('translatedKey', VARCHAR(length=200), primary_key=True, autoincrement=False, nullable=False),
+		Column('tcGroupID', INTEGER()),
+		Column('tcID', INTEGER()),
+		schema=schema
+	)
+
+
+	trnTranslationColumns =  Table('trnTranslationColumns', metadata,
+		Column('tcGroupID', INTEGER()),
+		Column('tcID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('tableName', VARCHAR(length=256), nullable=False),
+		Column('columnName', VARCHAR(length=128), nullable=False),
+		Column('masterID', VARCHAR(length=128)),
+		schema=schema
+	)
+
+
+	trnTranslationLanguages =  Table('trnTranslationLanguages', metadata,
+		Column('numericLanguageID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('languageID', VARCHAR(length=50)),
+		Column('languageName', VARCHAR(length=200)),
+		schema=schema
+	)
+
+
+	trnTranslations =  Table('trnTranslations', metadata,
+		Column('tcID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('keyID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('languageID', VARCHAR(length=50), primary_key=True, autoincrement=False, nullable=False),
+		Column('text',UnicodeText(), nullable=False),
+		schema=schema
+	)
+
+
+	warCombatZoneSystems =  Table('warCombatZoneSystems', metadata,
+		Column('solarSystemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('combatZoneID', INTEGER()),
+		schema=schema
+	)
+
+
+	warCombatZones =  Table('warCombatZones', metadata,
+		Column('combatZoneID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
+		Column('combatZoneName', VARCHAR(length=100)),
+		Column('factionID', INTEGER()),
+		Column('centerSystemID', INTEGER()),
+		Column('description', VARCHAR(length=500)),
+		schema=schema
+	)
+
+	return metadata
 
-    return metadata

--- a/tableloader/tables.py
+++ b/tableloader/tables.py
@@ -574,9 +574,9 @@ def metadataCreator(schema):
 
     invPositions =  Table('invPositions', metadata,
             Column('itemID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('x', FLOAT(), nullable=False, default=text(u"'0'")),
-            Column('y', FLOAT(), nullable=False, default=text(u"'0'")),
-            Column('z', FLOAT(), nullable=False, default=text(u"'0'")),
+            Column('x', FLOAT(), nullable=False, default=text("'0'")),
+            Column('y', FLOAT(), nullable=False, default=text("'0'")),
+            Column('z', FLOAT(), nullable=False, default=text("'0'")),
             Column('yaw', FLOAT(precision=24)),
             Column('pitch', FLOAT(precision=24)),
             Column('roll', FLOAT(precision=24)),
@@ -602,7 +602,7 @@ def metadataCreator(schema):
     invTypeMaterials =  Table('invTypeMaterials', metadata,
             Column('typeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
             Column('materialTypeID', INTEGER(), primary_key=True, autoincrement=False, nullable=False),
-            Column('quantity', INTEGER(), nullable=False, default=text(u"'0'")),
+            Column('quantity', INTEGER(), nullable=False, default=text("'0'")),
             schema=schema
 
 


### PR DESCRIPTION
updated from https://github.com/fuzzysteve/yamlloader/commit/1f6b3206511834be1684e5a977a40e475bdee482

two things:

1) the dogma loaders now populate the dgmAttributeCategories, dgmAttributeTypes, dgmEffects, dgmTypeEffects, dgmTypeAttributes tables from fsd. when we get to the bsdTables.py loader we break constraints re-populate these tables from bsd. add code to skip them from bsdTables.py loader to avoid breaking.

2) python3 (3.7)

tested on sqlite / mysql / postgres
